### PR TITLE
Implement voronoi binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 
+dist: xenial
+
 rust:
   - stable
   - beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ failure = "0.1"
 failure_derive = "0.1"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.1"
+wkt = "0.1.3"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geos"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Matthieu Viry <matthieu.viry@cnrs.fr>", "Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 license = "MIT"
 repository = "https://github.com/georust/geos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geos"
-version = "2.0.3"
+version = "2.1.0"
 authors = ["Matthieu Viry <matthieu.viry@cnrs.fr>", "Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 license = "MIT"
 repository = "https://github.com/georust/geos"
@@ -13,12 +13,13 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 num = "0.1"
-geo-types = "0.1"
+geo-types = "0.2.0"
 failure = "0.1"
 failure_derive = "0.1"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.1"
-wkt = "0.1.3"
+# wkt = "0.1.3"
+wkt = { version = "0.2.0", git = "https://github.com/georust/wkt.git", rev = "e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2" }
 
 [build-dependencies]
 skeptic = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geos"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["Matthieu Viry <matthieu.viry@cnrs.fr>", "Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 license = "MIT"
 repository = "https://github.com/georust/geos"
@@ -18,7 +18,6 @@ failure = "0.1"
 failure_derive = "0.1"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.1"
-# wkt = "0.1.3"
 wkt = { version = "0.2.0", git = "https://github.com/georust/wkt.git", rev = "e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2" }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ failure = "0.1"
 failure_derive = "0.1"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.1"
-wkt = { version = "0.2.0", git = "https://github.com/georust/wkt.git", rev = "e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2" }
+wkt = "0.2.1"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@ Complete example can be found in `examples/from_geo.rs`
 
 ```rust,skt-template
 use geos::from_geo::TryInto;
-use geo_types::{LineString, Point, Polygon};
+use geo_types::{LineString, Coordinate, Polygon};
 
 // first we create a Geo object
 let exterior = LineString(vec![
-    Point::new(0., 0.),
-    Point::new(0., 1.),
-    Point::new(1., 1.),
+    Coordinate::from((0., 0.)),
+    Coordinate::from((0., 1.)),
+    Coordinate::from((1., 1.)),
 ]);
 let interiors = vec![
     LineString(vec![
-        Point::new(0.1, 0.1),
-        Point::new(0.1, 0.9),
-        Point::new(0.9, 0.9),
+        Coordinate::from((0.1, 0.1)),
+        Coordinate::from((0.1, 0.9)),
+        Coordinate::from((0.9, 0.9)),
     ]),
 ];
 let p = Polygon::new(exterior, interiors);
@@ -85,7 +85,7 @@ let points = vec![
     Point::new(1., 0.),
 ];
 
-let _voronoi = geos::compute_voronoi(&points, 0.).unwrap();
+let _voronoi = geos::compute_voronoi(&points, 0.)?;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ let _geom: geos::GGeom = (&p).try_into()?;
 // do some stuff with _geom
 ```
 
+### Voronoi
+
+[Voronoi](https://en.wikipedia.org/wiki/Voronoi_diagram) diagrams computation are available in the bindings.
+
+For those to be easier to use with [rust-geo](https://github.com/georust/rust-geo) some helpers are available in `voronoi.rs`.
+
+```rust,skt-template
+use geo_types::Point;
+let points = vec![
+    Point::new(0., 0.),
+    Point::new(0., 1.),
+    Point::new(1., 1.),
+    Point::new(1., 0.),
+];
+
+let _voronoi = geos::compute_voronoi(&points, 0.).unwrap();
+```
+
+
 ## Contributing
 
 Only a subset of geos has been implemented, feel free to add wrappers for missing features.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ geos
 
 Rust bindings for [GEOS](https://trac.osgeo.org/geos/) C API.
 
-### Disclaimer
+The supported geos version is >= 3.5
 
-Work in progress (currently it's probably poorly designed, incomplete and containing beginners errors)
+### Disclaimer
 
 GEOS can be a tad strict on the validity on the input geometry and is prone to crash on invalid input, so they need to be checked in the wrapper.
 This project is checked with valgrind, but if you stumble on a crash feel free to open an issue explaining the problem.

--- a/examples/from_geo.rs
+++ b/examples/from_geo.rs
@@ -1,26 +1,26 @@
 extern crate geos;
 extern crate geo_types;
 extern crate failure;
-use geos::GGeom;
-use geo_types::{LineString, Point, Polygon};
-use geos::from_geo::TryInto;
-use failure::Error;
 
+use failure::Error;
 fn fun() -> Result<(), Error> {
+use geos::GGeom;
+use geo_types::{LineString, Polygon, Coordinate};
+use geos::from_geo::TryInto;
     let exterior = LineString(vec![
-        Point::new(0., 0.),
-        Point::new(0., 1.),
-        Point::new(1., 1.),
-        Point::new(1., 0.),
-        Point::new(0., 0.),
+        Coordinate::from((0., 0.)),
+        Coordinate::from((0., 1.)),
+        Coordinate::from((1., 1.)),
+        Coordinate::from((1., 0.)),
+        Coordinate::from((0., 0.)),
     ]);
     let interiors = vec![
         LineString(vec![
-            Point::new(0.1, 0.1),
-            Point::new(0.1, 0.9),
-            Point::new(0.9, 0.9),
-            Point::new(0.9, 0.1),
-            Point::new(0.1, 0.1),
+            Coordinate::from((0.1, 0.1)),
+            Coordinate::from((0.1, 0.9)),
+            Coordinate::from((0.9, 0.9)),
+            Coordinate::from((0.9, 0.1)),
+            Coordinate::from((0.1, 0.1)),
         ]),
     ];
     let p = Polygon::new(exterior.clone(), interiors.clone());

--- a/examples/verbose_example.rs
+++ b/examples/verbose_example.rs
@@ -25,7 +25,7 @@ fn fun() -> Result<(), Error> {
     println!("Centroid of g1 : {:?}", g4.to_wkt());
     println!(
         "Centroid of g1 with round precision of 1: {:?}",
-        g4.to_wkt_precison(Some(1))
+        g4.to_wkt_precision(Some(1))
     );
     println!("Geom4 contains centroid of geom1 : {:?}", g3.contains(&g4)?);
     println!("Geom4 is valid ? : {}", g3.is_valid());

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,8 @@ pub enum PredicateType {
     PreparedIntersects,
     PreparedOverlaps,
     PreparedTouches,
-    PreparedWithin
+    PreparedWithin,
+    Normalize,
 }
 
 impl std::fmt::Display for PredicateType {

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,10 +8,16 @@ pub enum Error {
     ImpossibleOperation(String),
     #[fail(display = "error while calling libgeos while {}", _0)]
     GeosError(String),
-    #[fail(display = "error while calling libgeos method {} (error number = {})", _0, _1)]
+    #[fail(
+        display = "error while calling libgeos method {} (error number = {})",
+        _0,
+        _1
+    )]
     GeosFunctionError(PredicateType, i32),
     #[fail(display = "impossible to build a geometry from a nullptr")]
     NoConstructionFromNullPtr,
+    #[fail(display = "impossible to convert geometry, {}", _0)]
+    ConversionError(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -631,7 +631,7 @@ impl GGeom {
     pub fn voronoi(
         &self,
         envelope: Option<&GGeom>,
-        tolerance: f32,
+        tolerance: f64,
         only_edges: bool,
     ) -> GeosResult<GGeom> {
         unsafe {

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -91,6 +91,8 @@ impl<'a> TryInto<GGeom> for &'a MultiPolygon<f64> {
     }
 }
 
+
+
 #[cfg(test)]
 mod test {
     use geo_types::{LineString, MultiPolygon, Point, Polygon};

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -1,4 +1,4 @@
-use geo_types::{LineString, MultiPolygon, Polygon, Point};
+use geo_types::{LineString, MultiPolygon, Polygon, Point, Coordinate};
 use ffi::{CoordSeq, GGeom};
 use error::Error;
 use std;
@@ -9,17 +9,17 @@ pub trait TryInto<T> {
     fn try_into(self) -> Result<T, Self::Err>;
 }
 
-fn create_coord_seq_from_vec<'a>(points: &'a[Point<f64>]) -> Result<CoordSeq, Error> {
-    create_coord_seq(points.iter(), points.len())
+fn create_coord_seq_from_vec<'a>(coords: &'a[Coordinate<f64>]) -> Result<CoordSeq, Error> {
+    create_coord_seq(coords.iter(), coords.len())
 }
 
 fn create_coord_seq<'a, It>(points: It, len: usize) -> Result<CoordSeq, Error>
-where It: Iterator<Item = &'a Point<f64>> {
+where It: Iterator<Item = &'a Coordinate<f64>> {
     let mut coord_seq = CoordSeq::new(len as u32, 2);
     for (i, p) in points.enumerate() {
         let j = i as u32;
-        coord_seq.set_x(j, p.x())?;
-        coord_seq.set_y(j, p.y())?;
+        coord_seq.set_x(j, p.x)?;
+        coord_seq.set_y(j, p.y)?;
     }
     Ok(coord_seq)
 }
@@ -28,7 +28,7 @@ impl<'a> TryInto<GGeom> for &'a Point<f64> {
     type Err = Error;
 
     fn try_into(self) -> Result<GGeom, Self::Err> {
-        let coord_seq = create_coord_seq(std::iter::once(self), 1)?;
+        let coord_seq = create_coord_seq(std::iter::once(&self.0), 1)?;
 
         GGeom::create_point(coord_seq)
     }
@@ -118,28 +118,32 @@ impl<'a> TryInto<GGeom> for &'a MultiPolygon<f64> {
 
 #[cfg(test)]
 mod test {
-    use geo_types::{LineString, MultiPolygon, Point, Polygon};
+    use geo_types::{LineString, MultiPolygon, Polygon, Coordinate};
     use ffi::GGeom;
     use from_geo::TryInto;
     use super::LineRing;
 
+    fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
+        tuples.into_iter().map(Coordinate::from).collect()
+    }
+
     #[test]
     fn polygon_contains_test() {
-        let exterior = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(1., 1.),
-            Point::new(1., 0.),
-            Point::new(0., 0.),
-        ]);
+        let exterior = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (1., 1.),
+            (1., 0.),
+            (0., 0.),
+        ]));
         let interiors = vec![
-            LineString(vec![
-                Point::new(0.1, 0.1),
-                Point::new(0.1, 0.9),
-                Point::new(0.9, 0.9),
-                Point::new(0.9, 0.1),
-                Point::new(0.1, 0.1),
-            ]),
+            LineString(coords(vec![
+                (0.1, 0.1),
+                (0.1, 0.9),
+                (0.9, 0.9),
+                (0.9, 0.1),
+                (0.1, 0.1),
+            ])),
         ];
         let p = Polygon::new(exterior.clone(), interiors.clone());
 
@@ -157,21 +161,21 @@ mod test {
 
     #[test]
     fn multipolygon_contains_test() {
-        let exterior = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(1., 1.),
-            Point::new(1., 0.),
-            Point::new(0., 0.),
-        ]);
+        let exterior = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (1., 1.),
+            (1., 0.),
+            (0., 0.),
+        ]));
         let interiors = vec![
-            LineString(vec![
-                Point::new(0.1, 0.1),
-                Point::new(0.1, 0.9),
-                Point::new(0.9, 0.9),
-                Point::new(0.9, 0.1),
-                Point::new(0.1, 0.1),
-            ]),
+            LineString(coords(vec![
+                (0.1, 0.1),
+                (0.1, 0.9),
+                (0.9, 0.9),
+                (0.9, 0.1),
+                (0.1, 0.1),
+            ])),
         ];
         let p = Polygon::new(exterior, interiors);
         let mp = MultiPolygon(vec![p.clone()]);
@@ -184,9 +188,9 @@ mod test {
 
     #[test]
     fn incorrect_multipolygon_test() {
-        let exterior = LineString(vec![
-            Point::new(0., 0.)
-        ]);
+        let exterior = LineString(coords(vec![
+            (0., 0.)
+        ]));
         let interiors = vec![];
         let p = Polygon::new(exterior, interiors);
         let mp = MultiPolygon(vec![p.clone()]);
@@ -199,21 +203,21 @@ mod test {
     #[test]
     fn incorrect_polygon_not_closed() {
         // even if the polygon is not closed we can convert it to geos (we close it)
-        let exterior = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 2.),
-            Point::new(2., 2.),
-            Point::new(2., 0.),
-            Point::new(0., 0.),
-        ]);
+        let exterior = LineString(coords(vec![
+            (0., 0.),
+            (0., 2.),
+            (2., 2.),
+            (2., 0.),
+            (0., 0.),
+        ]));
         let interiors = vec![
-            LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(1., 1.),
-            Point::new(1., 0.),
-            Point::new(0., 10.),
-            ]),
+            LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (1., 1.),
+            (1., 0.),
+            (0., 10.),
+            ])),
         ];
         let p = Polygon::new(exterior, interiors);
         let mp = MultiPolygon(vec![p]);
@@ -235,9 +239,9 @@ mod test {
     /// a linear ring should have at least 3 elements
     #[test]
     fn one_elt_linear_ring() {
-        let ls = LineString(vec![
-            Point::new(0., 0.),
-        ]);
+        let ls = LineString(coords(vec![
+            (0., 0.),
+        ]));
         let geom: Result<GGeom, _> = LineRing(&ls).try_into();
         let error = geom.err().unwrap();
         assert_eq!(format!("{}", error), "Invalid geometry, impossible to create a LinearRing, A LinearRing must have at least 3 coordinates".to_string());
@@ -246,10 +250,10 @@ mod test {
     /// a linear ring should have at least 3 elements
     #[test]
     fn two_elt_linear_ring() {
-        let ls = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-        ]);
+        let ls = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+        ]));
         let geom: Result<GGeom, _> = LineRing(&ls).try_into();
         let error = geom.err().unwrap();
         assert_eq!(format!("{}", error), "Invalid geometry, impossible to create a LinearRing, A LinearRing must have at least 3 coordinates".to_string());
@@ -258,11 +262,11 @@ mod test {
     /// an unclosed linearring is valid since we close it before giving it to geos
     #[test]
     fn unclosed_linear_ring() {
-        let ls = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(1., 2.),
-         ]);
+        let ls = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (1., 2.),
+         ]));
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());
@@ -284,11 +288,11 @@ mod test {
     /// shapely (the python geos wrapper) considers that too
     #[test]
     fn closed_2_points_linear_ring() {
-        let ls = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(0., 0.),
-         ]);
+        let ls = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (0., 0.),
+         ]));
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());
@@ -299,12 +303,12 @@ mod test {
     /// a linear ring can be empty
     #[test]
     fn good_linear_ring() {
-        let ls = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(1., 2.),
-            Point::new(0., 0.),
-         ]);
+        let ls = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (1., 2.),
+            (0., 0.),
+         ]));
         let geom: GGeom = LineRing(&ls).try_into().unwrap();
 
         assert!(geom.is_valid());

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -24,6 +24,29 @@ where It: Iterator<Item = &'a Point<f64>> {
     Ok(coord_seq)
 }
 
+impl<'a> TryInto<GGeom> for &'a Point<f64> {
+    type Err = Error;
+
+    fn try_into(self) -> Result<GGeom, Self::Err> {
+        let coord_seq = create_coord_seq(std::iter::once(self), 1)?;
+
+        GGeom::create_point(coord_seq)
+    }
+}
+
+impl<'a> TryInto<GGeom> for &'a [Point<f64>] {
+    type Err = Error;
+
+    fn try_into(self) -> Result<GGeom, Self::Err> {
+        let geom_points = self
+            .into_iter()
+            .map(|p| p.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        GGeom::create_multipoint(geom_points)
+    }
+}
+
 impl<'a> TryInto<GGeom> for &'a LineString<f64> {
     type Err = Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub use ffi::{version, CoordSeq, GGeom, PreparedGGeom};
 pub mod from_geo;
 mod error;
 pub use error::Error;
+mod voronoi;
+pub use voronoi::compute_voronoi;
 
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,11 @@ extern crate enum_primitive_derive;
 extern crate num_traits;
 extern crate wkt;
 
-
 mod ffi;
 pub use ffi::{version, CoordSeq, GGeom, PreparedGGeom};
+mod error;
 pub mod from_geo;
 pub mod to_geo;
-mod error;
 pub use error::Error;
 mod voronoi;
 pub use voronoi::compute_voronoi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,13 @@ extern crate failure;
 #[macro_use]
 extern crate enum_primitive_derive;
 extern crate num_traits;
+extern crate wkt;
 
 
 mod ffi;
 pub use ffi::{version, CoordSeq, GGeom, PreparedGGeom};
 pub mod from_geo;
+pub mod to_geo;
 mod error;
 pub use error::Error;
 mod voronoi;

--- a/src/to_geo.rs
+++ b/src/to_geo.rs
@@ -1,0 +1,47 @@
+use error::Error;
+use ffi::GGeom;
+use from_geo::TryInto;
+use geo_types::Geometry;
+use wkt;
+use wkt::conversion::try_into_geometry;
+
+impl<'a> TryInto<Geometry<f64>> for GGeom {
+    type Err = Error;
+
+    fn try_into(self) -> Result<Geometry<f64>, Self::Err> {
+        let wkt_str = self.to_wkt();
+        let wkt_obj = wkt::Wkt::from_str(&wkt_str)
+            .map_err(|e| Error::ConversionError(format!("impossible to read wkt: {}", e)))?;
+
+        let o: &wkt::Geometry = wkt_obj.items.iter().next().ok_or(Error::ConversionError("invalid wkt".into()))?;
+
+        try_into_geometry(o)
+            .map_err(|e| Error::ConversionError(format!("impossible to built from wkt: {}", e)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ffi::GGeom;
+    use from_geo::TryInto;
+    use geo_types::{Geometry, LineString, MultiPolygon, Point, Polygon};
+
+    #[test]
+    fn geom_to_geo_polygon() {
+        let poly = "MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))";
+        let poly = GGeom::new(poly).unwrap();
+
+        let geo_polygon: Geometry<f64> = poly.try_into().unwrap();
+
+        let exterior = LineString(vec![
+            Point::new(0., 0.),
+            Point::new(0., 1.),
+            Point::new(1., 1.),
+            Point::new(1., 0.),
+            Point::new(0., 0.),
+        ]);
+        let expected_poly = MultiPolygon(vec![Polygon::new(exterior, vec![])]);
+        let expected: Geometry<_> = expected_poly.into();
+        assert_eq!(expected, geo_polygon);
+    }
+}

--- a/src/to_geo.rs
+++ b/src/to_geo.rs
@@ -31,7 +31,11 @@ impl<'a> TryInto<Geometry<f64>> for GGeom {
 mod test {
     use ffi::GGeom;
     use from_geo::TryInto;
-    use geo_types::{Geometry, LineString, MultiPolygon, Point, Polygon};
+    use geo_types::{Geometry, LineString, MultiPolygon, Coordinate, Polygon};
+
+    fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
+        tuples.into_iter().map(Coordinate::from).collect()
+    }
 
     #[test]
     fn geom_to_geo_polygon() {
@@ -40,13 +44,13 @@ mod test {
 
         let geo_polygon: Geometry<f64> = poly.try_into().unwrap();
 
-        let exterior = LineString(vec![
-            Point::new(0., 0.),
-            Point::new(0., 1.),
-            Point::new(1., 1.),
-            Point::new(1., 0.),
-            Point::new(0., 0.),
-        ]);
+        let exterior = LineString(coords(vec![
+            (0., 0.),
+            (0., 1.),
+            (1., 1.),
+            (1., 0.),
+            (0., 0.),
+        ]));
         let expected_poly = MultiPolygon(vec![Polygon::new(exterior, vec![])]);
         let expected: Geometry<_> = expected_poly.into();
         assert_eq!(expected, geo_polygon);

--- a/src/to_geo.rs
+++ b/src/to_geo.rs
@@ -9,14 +9,18 @@ impl<'a> TryInto<Geometry<f64>> for GGeom {
     type Err = Error;
 
     fn try_into(self) -> Result<Geometry<f64>, Self::Err> {
-        // This is a first draft, it's very inefficient, we use wkt as a pivot format to 
+        // This is a first draft, it's very inefficient, we use wkt as a pivot format to
         // translate the geometry.
         // We should at least use wkb, or even better implement a direct translation
         let wkt_str = self.to_wkt();
         let wkt_obj = wkt::Wkt::from_str(&wkt_str)
             .map_err(|e| Error::ConversionError(format!("impossible to read wkt: {}", e)))?;
 
-        let o: &wkt::Geometry = wkt_obj.items.iter().next().ok_or(Error::ConversionError("invalid wkt".into()))?;
+        let o: &wkt::Geometry = wkt_obj
+            .items
+            .iter()
+            .next()
+            .ok_or(Error::ConversionError("invalid wkt".into()))?;
 
         try_into_geometry(o)
             .map_err(|e| Error::ConversionError(format!("impossible to built from wkt: {}", e)))

--- a/src/to_geo.rs
+++ b/src/to_geo.rs
@@ -9,6 +9,9 @@ impl<'a> TryInto<Geometry<f64>> for GGeom {
     type Err = Error;
 
     fn try_into(self) -> Result<Geometry<f64>, Self::Err> {
+        // This is a first draft, it's very inefficient, we use wkt as a pivot format to 
+        // translate the geometry.
+        // We should at least use wkb, or even better implement a direct translation
         let wkt_str = self.to_wkt();
         let wkt_obj = wkt::Wkt::from_str(&wkt_str)
             .map_err(|e| Error::ConversionError(format!("impossible to read wkt: {}", e)))?;

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -13,19 +13,21 @@ pub fn compute_voronoi(points: &[Point<f64>], tolerance: f64) -> Result<Vec<Poly
         .and_then(|g: Geometry<f64>| match g {
             Geometry::GeometryCollection(gc) => Ok(gc),
             _ => Err(Error::ConversionError("invalid geometry type".into())),
-        }).and_then(|gc: GeometryCollection<f64>| {
+        })
+        .and_then(|gc: GeometryCollection<f64>| {
             gc.0.into_iter()
                 .map(|g| {
                     g.as_polygon()
                         .ok_or(Error::ConversionError("invalid inner geometry type".into()))
-                }).collect()
+                })
+                .collect()
         })
 }
 
 #[cfg(test)]
 mod test {
     use ffi::GGeom;
-    use geo_types::{LineString, Point, Polygon, Coordinate};
+    use geo_types::{Coordinate, LineString, Point, Polygon};
     /// create a voronoi diagram. Same unit test as https://github.com/libgeos/geos/blob/master/tests/unit/triangulate/VoronoiTest.cpp#L118
     #[test]
     fn simple_voronoi() {
@@ -78,7 +80,6 @@ mod test {
     fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
         tuples.into_iter().map(Coordinate::from).collect()
     }
-
 
     // test the rust-geo voronoi wrapper
     #[test]

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -25,7 +25,7 @@ pub fn compute_voronoi(points: &[Point<f64>], tolerance: f32) -> Result<Vec<Poly
 #[cfg(test)]
 mod test {
     use ffi::GGeom;
-    use geo_types::{LineString, Point, Polygon};
+    use geo_types::{LineString, Point, Polygon, Coordinate};
     /// create a voronoi diagram. Same unit test as https://github.com/libgeos/geos/blob/master/tests/unit/triangulate/VoronoiTest.cpp#L118
     #[test]
     fn simple_voronoi() {
@@ -75,6 +75,11 @@ mod test {
         assert!(same);
     }
 
+    fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
+        tuples.into_iter().map(Coordinate::from).collect()
+    }
+
+
     // test the rust-geo voronoi wrapper
     #[test]
     fn geo_voronoi() {
@@ -89,43 +94,43 @@ mod test {
 
         let poly = vec![
             Polygon::new(
-                LineString(vec![
-                    Point::new(0.5, 2.0),
-                    Point::new(2.0, 2.0),
-                    Point::new(2.0, 0.5),
-                    Point::new(0.5, 0.5),
-                    Point::new(0.5, 2.0),
-                ]),
+                LineString(coords(vec![
+                    (0.5, 2.0),
+                    (2.0, 2.0),
+                    (2.0, 0.5),
+                    (0.5, 0.5),
+                    (0.5, 2.0),
+                ])),
                 vec![],
             ),
             Polygon::new(
-                LineString(vec![
-                    Point::new(-1.0, 0.5),
-                    Point::new(-1.0, 2.0),
-                    Point::new(0.5, 2.0),
-                    Point::new(0.5, 0.5),
-                    Point::new(-1.0, 0.5),
-                ]),
+                LineString(coords(vec![
+                    (-1.0, 0.5),
+                    (-1.0, 2.0),
+                    (0.5, 2.0),
+                    (0.5, 0.5),
+                    (-1.0, 0.5),
+                ])),
                 vec![],
             ),
             Polygon::new(
-                LineString(vec![
-                    Point::new(0.5, -1.0),
-                    Point::new(-1.0, -1.0),
-                    Point::new(-1.0, 0.5),
-                    Point::new(0.5, 0.5),
-                    Point::new(0.5, -1.0),
-                ]),
+                LineString(coords(vec![
+                    (0.5, -1.0),
+                    (-1.0, -1.0),
+                    (-1.0, 0.5),
+                    (0.5, 0.5),
+                    (0.5, -1.0),
+                ])),
                 vec![],
             ),
             Polygon::new(
-                LineString(vec![
-                    Point::new(2.0, 0.5),
-                    Point::new(2.0, -1.0),
-                    Point::new(0.5, -1.0),
-                    Point::new(0.5, 0.5),
-                    Point::new(2.0, 0.5),
-                ]),
+                LineString(coords(vec![
+                    (2.0, 0.5),
+                    (2.0, -1.0),
+                    (0.5, -1.0),
+                    (0.5, 0.5),
+                    (2.0, 0.5),
+                ])),
                 vec![],
             ),
         ];

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -3,6 +3,7 @@ use ffi::GGeom;
 use from_geo::TryInto;
 use geo_types::{Geometry, GeometryCollection, Point, Polygon};
 
+//TODO, change  &[] to IntoIterator
 pub fn compute_voronoi(points: &[Point<f64>], tolerance: f32) -> Result<Vec<Polygon<f64>>, Error> {
     let geom_points: GGeom = points.try_into()?;
 

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -1,15 +1,31 @@
-use geo_types::{Polygon, Point};
+use error::Error;
+use ffi::GGeom;
+use from_geo::TryInto;
+use geo_types::{Geometry, GeometryCollection, Point, Polygon};
 
-pub fn compute_voronoi(points: &[Point<f64>]) -> Vec<Polygon<f64>> {
-    // let GGeom = 
-    unimplemented!()
+pub fn compute_voronoi(points: &[Point<f64>], tolerance: f32) -> Result<Vec<Polygon<f64>>, Error> {
+    let geom_points: GGeom = points.try_into()?;
+
+    geom_points
+        .voronoi(None, tolerance, false)?
+        .try_into()
+        .and_then(|g: Geometry<f64>| match g {
+            Geometry::GeometryCollection(gc) => Ok(gc),
+            _ => Err(Error::ConversionError("invalid geometry type".into())),
+        }).and_then(|gc: GeometryCollection<f64>| {
+            gc.0.into_iter()
+                .map(|g| {
+                    g.as_polygon()
+                        .ok_or(Error::ConversionError("invalid inner geometry type".into()))
+                }).collect()
+        })
 }
 
 #[cfg(test)]
 mod test {
-    use geo_types::{Polygon, Point};
     use ffi::GGeom;
-    /// create a voronoi diagram 
+    use geo_types::{LineString, Point, Polygon};
+    /// create a voronoi diagram. Same unit test as https://github.com/libgeos/geos/blob/master/tests/unit/triangulate/VoronoiTest.cpp#L118
     #[test]
     fn simple_voronoi() {
         let points = "MULTIPOINT ((150 200), (180 270), (275 163))";
@@ -23,16 +39,15 @@ mod test {
             POLYGON ((25 295, 25 395, 400 395, 400 369.6542056074766, 221.20588235294116 210.91176470588235, 25 295)))";
 
         let mut expected_output = GGeom::new(expected_output).unwrap();
-        let wkt_output = voronoi.to_wkt();
 
         expected_output.normalize().unwrap();
         voronoi.normalize().unwrap();
-        println!("voronoi: {}", wkt_output);
 
         let same = expected_output.equals_exact(&voronoi, 1e-3).unwrap();
         assert!(same);
     }
 
+    /// test precision. Same unit test as https://github.com/libgeos/geos/blob/master/tests/unit/triangulate/VoronoiTest.cpp#L160
     #[test]
     fn wkt_voronoi_precision() {
         let points = "MULTIPOINT ((100 200), (105 202), (110 200), (140 230), 
@@ -42,7 +57,7 @@ mod test {
         let mut voronoi = input.voronoi(None, 6., false).unwrap();
 
         let expected_output = "GEOMETRYCOLLECTION (
-            POLYGON ((-20 50, -20 380, -3.75 380, 105 235, 105 115, 77.14285714285714 50, -20 50)),
+        POLYGON ((-20 50, -20 380, -3.75 380, 105 235, 105 115, 77.14285714285714 50, -20 50)),
         POLYGON ((247 50, 77.14285714285714 50, 105 115, 145 195, 178.33333333333334 211.66666666666666, 183.51851851851853 208.7037037037037, 247 50)), 
         POLYGON ((-3.75 380, 20.000000000000007 380, 176.66666666666666 223.33333333333334, 178.33333333333334 211.66666666666666, 145 195, 105 235, -3.75 380)), 
         POLYGON ((105 115, 105 235, 145 195, 105 115)), 
@@ -51,13 +66,69 @@ mod test {
         POLYGON ((340 240, 340 50, 247 50, 183.51851851851853 208.7037037037037, 340 240)))";
 
         let mut expected_output = GGeom::new(expected_output).unwrap();
-        let wkt_output = voronoi.to_wkt();
 
         expected_output.normalize().unwrap();
         voronoi.normalize().unwrap();
-        println!("voronoi: {}", wkt_output);
 
         let same = expected_output.equals_exact(&voronoi, 1e-3).unwrap();
         assert!(same);
+    }
+
+    // test the rust-geo voronoi wrapper
+    #[test]
+    fn geo_voronoi() {
+        let points = vec![
+            Point::new(0., 0.),
+            Point::new(0., 1.),
+            Point::new(1., 1.),
+            Point::new(1., 0.),
+        ];
+
+        let voronoi = ::compute_voronoi(&points, 0.).unwrap();
+
+        let poly = vec![
+            Polygon::new(
+                LineString(vec![
+                    Point::new(0.5, 2.0),
+                    Point::new(2.0, 2.0),
+                    Point::new(2.0, 0.5),
+                    Point::new(0.5, 0.5),
+                    Point::new(0.5, 2.0),
+                ]),
+                vec![],
+            ),
+            Polygon::new(
+                LineString(vec![
+                    Point::new(-1.0, 0.5),
+                    Point::new(-1.0, 2.0),
+                    Point::new(0.5, 2.0),
+                    Point::new(0.5, 0.5),
+                    Point::new(-1.0, 0.5),
+                ]),
+                vec![],
+            ),
+            Polygon::new(
+                LineString(vec![
+                    Point::new(0.5, -1.0),
+                    Point::new(-1.0, -1.0),
+                    Point::new(-1.0, 0.5),
+                    Point::new(0.5, 0.5),
+                    Point::new(0.5, -1.0),
+                ]),
+                vec![],
+            ),
+            Polygon::new(
+                LineString(vec![
+                    Point::new(2.0, 0.5),
+                    Point::new(2.0, -1.0),
+                    Point::new(0.5, -1.0),
+                    Point::new(0.5, 0.5),
+                    Point::new(2.0, 0.5),
+                ]),
+                vec![],
+            ),
+        ];
+
+        assert_eq!(poly, voronoi);
     }
 }

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -1,0 +1,63 @@
+use geo_types::{Polygon, Point};
+
+pub fn compute_voronoi(points: &[Point<f64>]) -> Vec<Polygon<f64>> {
+    // let GGeom = 
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod test {
+    use geo_types::{Polygon, Point};
+    use ffi::GGeom;
+    /// create a voronoi diagram 
+    #[test]
+    fn simple_voronoi() {
+        let points = "MULTIPOINT ((150 200), (180 270), (275 163))";
+        let input = GGeom::new(points).unwrap();
+
+        let mut voronoi = input.voronoi(None, 0., false).unwrap();
+
+        let expected_output = "GEOMETRYCOLLECTION (
+            POLYGON ((25 38, 25 295, 221.20588235294116 210.91176470588235, 170.024 38, 25 38)), 
+            POLYGON ((400 369.6542056074766, 400 38, 170.024 38, 221.20588235294116 210.91176470588235, 400 369.6542056074766)), 
+            POLYGON ((25 295, 25 395, 400 395, 400 369.6542056074766, 221.20588235294116 210.91176470588235, 25 295)))";
+
+        let mut expected_output = GGeom::new(expected_output).unwrap();
+        let wkt_output = voronoi.to_wkt();
+
+        expected_output.normalize().unwrap();
+        voronoi.normalize().unwrap();
+        println!("voronoi: {}", wkt_output);
+
+        let same = expected_output.equals_exact(&voronoi, 1e-3).unwrap();
+        assert!(same);
+    }
+
+    #[test]
+    fn wkt_voronoi_precision() {
+        let points = "MULTIPOINT ((100 200), (105 202), (110 200), (140 230), 
+        (210 240), (220 190), (170 170), (170 260), (213 245), (220 190))";
+        let input = GGeom::new(points).unwrap();
+
+        let mut voronoi = input.voronoi(None, 6., false).unwrap();
+
+        let expected_output = "GEOMETRYCOLLECTION (
+            POLYGON ((-20 50, -20 380, -3.75 380, 105 235, 105 115, 77.14285714285714 50, -20 50)),
+        POLYGON ((247 50, 77.14285714285714 50, 105 115, 145 195, 178.33333333333334 211.66666666666666, 183.51851851851853 208.7037037037037, 247 50)), 
+        POLYGON ((-3.75 380, 20.000000000000007 380, 176.66666666666666 223.33333333333334, 178.33333333333334 211.66666666666666, 145 195, 105 235, -3.75 380)), 
+        POLYGON ((105 115, 105 235, 145 195, 105 115)), 
+        POLYGON ((20.000000000000007 380, 255 380, 176.66666666666666 223.33333333333334, 20.000000000000007 380)), 
+        POLYGON ((255 380, 340 380, 340 240, 183.51851851851853 208.7037037037037, 178.33333333333334 211.66666666666666, 176.66666666666666 223.33333333333334, 255 380)), 
+        POLYGON ((340 240, 340 50, 247 50, 183.51851851851853 208.7037037037037, 340 240)))";
+
+        let mut expected_output = GGeom::new(expected_output).unwrap();
+        let wkt_output = voronoi.to_wkt();
+
+        expected_output.normalize().unwrap();
+        voronoi.normalize().unwrap();
+        println!("voronoi: {}", wkt_output);
+
+        let same = expected_output.equals_exact(&voronoi, 1e-3).unwrap();
+        assert!(same);
+    }
+}

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -44,7 +44,7 @@ mod test {
         expected_output.normalize().unwrap();
         voronoi.normalize().unwrap();
 
-        let same = expected_output.equals_exact(&voronoi, 1e-3).unwrap();
+        let same = expected_output.equals(&voronoi).unwrap();
         assert!(same);
     }
 
@@ -71,7 +71,7 @@ mod test {
         expected_output.normalize().unwrap();
         voronoi.normalize().unwrap();
 
-        let same = expected_output.equals_exact(&voronoi, 1e-3).unwrap();
+        let same = expected_output.equals(&voronoi).unwrap();
         assert!(same);
     }
 

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -4,7 +4,7 @@ use from_geo::TryInto;
 use geo_types::{Geometry, GeometryCollection, Point, Polygon};
 
 //TODO, change  &[] to IntoIterator
-pub fn compute_voronoi(points: &[Point<f64>], tolerance: f32) -> Result<Vec<Polygon<f64>>, Error> {
+pub fn compute_voronoi(points: &[Point<f64>], tolerance: f64) -> Result<Vec<Polygon<f64>>, Error> {
     let geom_points: GGeom = points.try_into()?;
 
     geom_points


### PR DESCRIPTION
add a binding to the libgeos [voronoi computation function](https://github.com/libgeos/geos/blob/master/capi/geos_c.h.in#L1710-L1714).

To use it more easily with [rust-geo](https://github.com/georust/geo) I added a simple wrapper to the geos binding.

It can thus be used either with pure geos:

```rust
let points = "MULTIPOINT ((150 200), (180 270), (275 163))";
let input = GGeom::new(points)?;
let voronoi = input.voronoi(None, 0., false)?;
```

or with rust-geo:
```rust
use geo_types::Point;
let points = vec![
    Point::new(0., 0.),
    Point::new(0., 1.),
    Point::new(1., 1.),
    Point::new(1., 0.),
];
let _voronoi = geos::compute_voronoi(&points, 0.)?;
```

For the moment to make the `geos -> geo` conversion, since I don't have much time (It's my last day in my current position :tada: ) I used [wkt](https://github.com/georust/wkt/) as a pivot format (thus  `geos -> wkt -> geo`) It's obviously very inefficient. We should at least use wkb, or even better custom converter.

This PR is usable, ibut it's still a bit WIP since I'd like to test it's use in a real use case (voronoi computation in [cosmogony](https://github.com/QwantResearch/cosmogony)
It's also WIp because it depends on https://github.com/georust/wkt/pull/38