### PR TITLE
Remove useless main.rs file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,0 @@
-#![cfg(not(test))]
-extern crate geos;
-use geos::version;
-
-fn main() {
-    println!("geos_c version: {}", version());
-}


### PR DESCRIPTION
I guess it just adds noise in the `src` folder (and it's pretty uncommon for `lib` crates).