### PR TITLE
Add create_multilinestring and create_geometrycollection

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -773,14 +773,14 @@ fn check_geos_predicate(val: i32, p: PredicateType) -> GeosResult<bool> {
 
 fn check_same_geometry_type(geoms: &[GGeom], geom_type: GEOSGeomTypes) -> bool {
     geoms.iter()
-        .map(|g|
-            if g.geometry_type()? == geom_type {
-                Ok(true)
+        .all(|g| {
+            let t = g.geometry_type();
+            if t.is_err() {
+                false
             } else {
-                Err(Error::InvalidGeometry("".to_string()))
+                t.unwrap() == geom_type
+            }
         })
-        .collect::<GeosResult<Vec<bool>>>()
-        .is_ok()
 }
 
 fn create_multi_geom(mut geoms: Vec<GGeom>, output_type: GEOSGeomTypes) -> GeosResult<GGeom> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -773,14 +773,7 @@ fn check_geos_predicate(val: i32, p: PredicateType) -> GeosResult<bool> {
 
 fn check_same_geometry_type(geoms: &[GGeom], geom_type: GEOSGeomTypes) -> bool {
     geoms.iter()
-        .all(|g| {
-            let t = g.geometry_type();
-            if t.is_err() {
-                false
-            } else {
-                t.unwrap() == geom_type
-            }
-        })
+        .all(|g| g.geometry_type().map(|t| t == geom_type).unwrap_or(false))
 }
 
 fn create_multi_geom(mut geoms: Vec<GGeom>, output_type: GEOSGeomTypes) -> GeosResult<GGeom> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -586,7 +586,7 @@ impl GGeom {
         if !check_same_geometry_type(&polygons, GEOSGeomTypes::Polygon) {
             return Err(
                 Error::ImpossibleOperation(
-                    "All the provided geometry have to be of type Polygon".to_string()));
+                    "all the provided geometry have to be of type Polygon".to_string()));
         }
         create_multi_geom(polygons, GEOSGeomTypes::MultiPolygon)
     }
@@ -595,7 +595,7 @@ impl GGeom {
         if !check_same_geometry_type(&linestrings, GEOSGeomTypes::LineString) {
             return Err(
                 Error::ImpossibleOperation(
-                    "All the provided geometry have to be of type LineString".to_string()));
+                    "all the provided geometry have to be of type LineString".to_string()));
         }
         create_multi_geom(linestrings, GEOSGeomTypes::MultiLineString)
     }
@@ -604,7 +604,7 @@ impl GGeom {
         if !check_same_geometry_type(&points, GEOSGeomTypes::Point) {
             return Err(
                 Error::ImpossibleOperation(
-                    "All the provided geometry have to be of type Point".to_string()));
+                    "all the provided geometry have to be of type Point".to_string()));
         }
         create_multi_geom(points, GEOSGeomTypes::MultiPoint)
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -578,42 +578,35 @@ impl GGeom {
         Ok(res)
     }
 
-    pub fn create_multipolygon(mut polygons: Vec<GGeom>) -> GeosResult<GGeom> {
-        let nb_polygons = polygons.len();
-        let res = unsafe {
-            GGeom::new_from_raw(GEOSGeom_createCollection(
-                GEOSGeomTypes::MultiPolygon as c_int,
-                polygons.as_mut_ptr() as *mut *mut GEOSGeometry,
-                nb_polygons as c_uint,
-            ))
-        }?;
-
-        // we'll transfert the ownership of the ptr to the new GGeom,
-        // so the old one needs to forget their c ptr to avoid double cleanup
-        for p in polygons {
-            mem::forget(p);
-        }
-
-        Ok(res)
+    pub fn create_geometrycollection(geoms: Vec<GGeom>) -> GeosResult<GGeom> {
+        create_multi_geom(geoms, GEOSGeomTypes::GeometryCollection)
     }
 
-    pub fn create_multipoint(mut points: Vec<GGeom>) -> GeosResult<GGeom> {
-        let nb_points = points.len();
-        let res = unsafe {
-            GGeom::new_from_raw(GEOSGeom_createCollection(
-                GEOSGeomTypes::MultiPoint as c_int,
-                points.as_mut_ptr() as *mut *mut GEOSGeometry,
-                nb_points as c_uint,
-            ))
-        }?;
-
-        // we'll transfert the ownership of the ptr to the new GGeom,
-        // so the old one needs to forget their c ptr to avoid double cleanup
-        for p in points {
-            mem::forget(p);
+    pub fn create_multipolygon(polygons: Vec<GGeom>) -> GeosResult<GGeom> {
+        if !check_same_geometry_type(&polygons, GEOSGeomTypes::Polygon) {
+            return Err(
+                Error::ImpossibleOperation(
+                    "All the provided geometry have to be of type Polygon".to_string()));
         }
+        create_multi_geom(polygons, GEOSGeomTypes::MultiPolygon)
+    }
 
-        Ok(res)
+    pub fn create_multilinestring(linestrings: Vec<GGeom>) -> GeosResult<GGeom> {
+        if !check_same_geometry_type(&linestrings, GEOSGeomTypes::LineString) {
+            return Err(
+                Error::ImpossibleOperation(
+                    "All the provided geometry have to be of type LineString".to_string()));
+        }
+        create_multi_geom(linestrings, GEOSGeomTypes::MultiLineString)
+    }
+
+    pub fn create_multipoint(points: Vec<GGeom>) -> GeosResult<GGeom> {
+        if !check_same_geometry_type(&points, GEOSGeomTypes::Point) {
+            return Err(
+                Error::ImpossibleOperation(
+                    "All the provided geometry have to be of type Point".to_string()));
+        }
+        create_multi_geom(points, GEOSGeomTypes::MultiPoint)
     }
 
     pub fn create_point(s: CoordSeq) -> GeosResult<GGeom> {
@@ -776,6 +769,37 @@ fn check_geos_predicate(val: i32, p: PredicateType) -> GeosResult<bool> {
         0 => Ok(false),
         _ => Err(Error::GeosFunctionError(p, val))
     }
+}
+
+fn check_same_geometry_type(geoms: &[GGeom], geom_type: GEOSGeomTypes) -> bool {
+    geoms.iter()
+        .map(|g|
+            if g.geometry_type()? == geom_type {
+                Ok(true)
+            } else {
+                Err(Error::InvalidGeometry("".to_string()))
+        })
+        .collect::<GeosResult<Vec<bool>>>()
+        .is_ok()
+}
+
+fn create_multi_geom(mut geoms: Vec<GGeom>, output_type: GEOSGeomTypes) -> GeosResult<GGeom> {
+    let nb_geoms = geoms.len();
+    let res = unsafe {
+        GGeom::new_from_raw(GEOSGeom_createCollection(
+            output_type as c_int,
+            geoms.as_mut_ptr() as *mut *mut GEOSGeometry,
+            nb_geoms as c_uint,
+        ))
+    }?;
+
+    // we'll transfert the ownership of the ptr to the new GGeom,
+    // so the old one needs to forget their c ptr to avoid double cleanup
+    for g in geoms {
+        mem::forget(g);
+    }
+
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -139,7 +139,7 @@ mod test {
 
         assert_eq!(
             format!("{}", e),
-            "Invalid geometry, All the provided geometry have to be of type Point".to_string(),
+            "Impossible operation, all the provided geometry have to be of type Point".to_string(),
         );
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -68,9 +68,79 @@ mod test {
     fn test_wkt_rounding_precision() {
         let g = GGeom::new("LINESTRING(0.0 0.0, 7.0 7.0, 45.0 50.5, 100.0 100.0)").unwrap();
         let wkt = g.to_wkt_precision(Some(0));
-        assert_eq!(true, wkt == "LINESTRING (0 0, 7 7, 45 50, 100 100)");
+        assert_eq!(wkt, "LINESTRING (0 0, 7 7, 45 50, 100 100)");
         let wkt2 = g.to_wkt();
         assert!(wkt2 != wkt);
+    }
+
+    #[test]
+    fn test_multipoint_from_vec_single() {
+        let vec_geoms = vec![
+            GGeom::new("POINT (1.3 2.4)").unwrap(),
+            GGeom::new("POINT (2.1 0.3)").unwrap(),
+            GGeom::new("POINT (3.1 4.7)").unwrap(),
+            GGeom::new("POINT (0.4 4.1)").unwrap(),
+        ];
+        let multi_point = GGeom::create_multipoint(vec_geoms).unwrap();
+        assert_eq!(
+            multi_point.to_wkt_precision(Some(1)),
+            "MULTIPOINT (1.3 2.4, 2.1 0.3, 3.1 4.7, 0.4 4.1)",
+        )
+    }
+
+    #[test]
+    fn test_multilinestring_from_vec_single() {
+        let vec_geoms = vec![
+            GGeom::new("LINESTRING(1 1,10 50,20 25)").unwrap(),
+            GGeom::new("LINESTRING (0 0, 7 7, 45 50, 100 100)").unwrap(),
+        ];
+        let multi_linestring = GGeom::create_multilinestring(vec_geoms).unwrap();
+        assert_eq!(
+            multi_linestring.to_wkt_precision(Some(0)),
+            "MULTILINESTRING ((1 1, 10 50, 20 25), (0 0, 7 7, 45 50, 100 100))",
+        )
+    }
+
+    #[test]
+    fn test_multipolygon_from_vec_single() {
+        let vec_geoms = vec![
+            GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))").unwrap(),
+            GGeom::new("POLYGON ((1 1, 1 3, 5 5, 5 0, 1 1))").unwrap(),
+        ];
+        let multi_polygon = GGeom::create_multipolygon(vec_geoms).unwrap();
+        assert_eq!(
+            multi_polygon.to_wkt_precision(Some(0)),
+            "MULTIPOLYGON (((0 0, 0 5, 5 5, 5 0, 0 0)), ((1 1, 1 3, 5 5, 5 0, 1 1)))",
+        );
+    }
+
+    #[test]
+    fn test_geometrycollection_from_vec_ggeom() {
+        let vec_geoms = vec![
+            GGeom::new("POINT (1 2)").unwrap(),
+            GGeom::new("LINESTRING(1 1,10 50,20 25)").unwrap(),
+            GGeom::new("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))").unwrap(),
+        ];
+        let gc = GGeom::create_geometrycollection(vec_geoms).unwrap();
+        assert_eq!(
+            gc.to_wkt_precision(Some(0)),
+            "GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 1, 10 50, 20 25), POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0)))",
+        );
+    }
+
+    #[test]
+    fn test_error_multi_from_vec_single() {
+        let vec_geoms = vec![
+            GGeom::new("POINT (1.3 2.4)").unwrap(),
+            GGeom::new("LINESTRING(1 1,10 50,20 25)").unwrap(),
+        ];
+        let multi_point = GGeom::create_multipoint(vec_geoms);
+        let e = multi_point.err().unwrap();
+
+        assert_eq!(
+            format!("{}", e),
+            "Invalid geometry, All the provided geometry have to be of type Point".to_string(),
+        );
     }
 
     fn assert_almost_eq(a: f64, b: f64) {


### PR DESCRIPTION
This PR adds `create_multilinestring` and `create_geometrycollection` methods (fixes #27) and forces to check the type of each geometry given in argument in `create_multipoint`, `create_multilinestring` and `create_multipolygon` methods (fixes #29).
