### PR TITLE
Allow conversion from/to GeoJSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - cargo build --features v3_7_0
   - cargo build --features v3_6_0
   - cargo test --features geo
+  - cargo test --features json
   - cargo test
   - cargo doc --features dox
   - cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ geo = ["geo-types", "wkt"]
 v3_6_0 = ["geos-sys/v3_6_0"]
 v3_7_0 = ["geos-sys/v3_7_0", "v3_6_0"]
 v3_8_0 = ["geos-sys/v3_8_0", "v3_7_0"]
-dox = ["geo-types", "wkt"]
+dox = ["geo-types", "wkt", "json"]
 
 [dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ dox = ["geo-types", "wkt", "json"]
 libc = "0.2"
 num = "0.2"
 c_vec = "1.3"
-geojson = { version = "0.16", optional = true }
+geojson = { version = "0.17", optional = true }
 geo-types = { version = "0.4", optional = true }
 wkt = { version = "0.5", optional = true }
 geos-sys = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Rust bindings for GEOS C API"
 readme = "README.md"
 
 [features]
+json = ["geojson"]
 geo = ["geo-types", "wkt"]
 v3_6_0 = ["geos-sys/v3_6_0"]
 v3_7_0 = ["geos-sys/v3_7_0", "v3_6_0"]
@@ -20,6 +21,7 @@ dox = ["geo-types", "wkt"]
 libc = "0.2"
 num = "0.2"
 c_vec = "1.3"
+geojson = { version = "0.16", optional = true }
 geo-types = { version = "0.4", optional = true }
 wkt = { version = "0.5", optional = true }
 geos-sys = "1.0"

--- a/src/from_geojson.rs
+++ b/src/from_geojson.rs
@@ -33,7 +33,8 @@ fn create_closed_coord_seq_from_vec<'a>(points: &'a [Vec<f64>]) -> Result<CoordS
     let nb_points = points.len();
     // if the geom is not closed we close it
     let is_closed = nb_points > 0 && points.first() == points.last();
-    // Note: we also need to close a 2 points closed linearring, cf test closed_2_points_linear_ring
+    // Note: we also need to close a 2 points closed linearring,
+    // as in `from_geo` module
     let need_closing = nb_points > 0 && (!is_closed || nb_points == 3);
     if need_closing {
         create_coord_seq(

--- a/src/from_geojson.rs
+++ b/src/from_geojson.rs
@@ -1,0 +1,276 @@
+use crate::{CoordDimensions, CoordSeq, Geometry as GGeom};
+use error::{GResult, Error};
+use geojson::{Value, Geometry};
+use std;
+// use std::borrow::Borrow;
+
+// define our own TryInto while the std trait is not stable
+pub trait TryInto<T> {
+    type Err;
+    fn try_into(self) -> Result<T, Self::Err>;
+}
+
+fn create_coord_seq_from_vec<'a>(coords: &'a [Vec<f64>]) -> Result<CoordSeq, Error> {
+    create_coord_seq(coords.iter(), coords.len())
+}
+
+fn create_coord_seq<'a, 'b, It>(points: It, len: usize) -> Result<CoordSeq<'b>, Error>
+where
+    It: Iterator<Item = &'a Vec<f64>>,
+{
+    let mut coord_seq = CoordSeq::new(len as u32, CoordDimensions::TwoD)
+        .expect("failed to create CoordSeq");
+
+    for (i, p) in points.enumerate() {
+        coord_seq.set_x(i, p[0])?;
+        coord_seq.set_y(i, p[1])?;
+    }
+    Ok(coord_seq)
+}
+
+impl<'a> TryInto<GGeom<'a>> for &'a Geometry {
+    type Err = Error;
+
+    fn try_into(self) -> Result<GGeom<'a>, Self::Err> {
+        match self.value {
+            Value::Point(ref c) => {
+                GGeom::create_point(create_coord_seq(std::iter::once(c), 1)?)
+            },
+            Value::MultiPoint(ref pts) =>  {
+                let ggpts = pts.iter()
+                    .map(|pt| {
+                        GGeom::create_point(create_coord_seq(std::iter::once(pt), 1)?)
+                    })
+                    .collect::<GResult<Vec<GGeom>>>()?;
+                GGeom::create_multipoint(ggpts)
+            },
+            Value::LineString(ref line) => {
+                let coord_seq = create_coord_seq_from_vec(line.as_slice())?;
+                GGeom::create_line_string(coord_seq)
+            },
+            Value::MultiLineString(ref lines) => {
+                let gglines = lines.iter()
+                    .map(|line| {
+                        let coord_seq = create_coord_seq_from_vec(line.as_slice())?;
+                        GGeom::create_line_string(coord_seq)
+                    })
+                    .collect::<GResult<Vec<GGeom>>>()?;
+                GGeom::create_multiline_string(gglines)
+            },
+            Value::Polygon(ref rings) => {
+                let exterior_ring = GGeom::create_linear_ring(
+                    create_coord_seq_from_vec(rings[0].as_slice())?
+                )?;
+                let interiors = rings.iter()
+                    .skip(1)
+                    .map(|r| {
+                        GGeom::create_linear_ring(
+                            create_coord_seq_from_vec(r.as_slice())?)
+                    })
+                    .collect::<GResult<Vec<GGeom>>>()?;
+                GGeom::create_polygon(exterior_ring, interiors)
+            },
+            Value::MultiPolygon(ref polygons) => {
+                let ggpolys = polygons.iter()
+                    .map(|rings|{
+                        let exterior_ring = GGeom::create_linear_ring(
+                            create_coord_seq_from_vec(rings[0].as_slice())?
+                        )?;
+                        let interiors = rings.iter()
+                            .skip(1)
+                            .map(|r| {
+                                GGeom::create_linear_ring(
+                                    create_coord_seq_from_vec(r.as_slice())?)
+                            })
+                            .collect::<GResult<Vec<GGeom>>>()?;
+                        GGeom::create_polygon(exterior_ring, interiors)
+                    })
+                    .collect::<GResult<Vec<GGeom>>>()?;
+                GGeom::create_multipolygon(ggpolys)
+            },
+            Value::GeometryCollection(ref geoms) => {
+                let _geoms = geoms
+                    .iter()
+                    .map(|ref geom| geom.try_into())
+                    .collect::<GResult<Vec<GGeom>>>()?;
+                GGeom::create_geometry_collection(_geoms)
+            }
+        }
+    }
+}
+
+
+// #[cfg(test)]
+// mod test {
+//     use super::GGeom;
+//     use super::LineRing;
+//     use from_geojson::TryInto;
+//     use geojson::{Geometry, Value};
+//
+//     fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
+//         tuples.into_iter().map(Coordinate::from).collect()
+//     }
+//
+//     #[test]
+//     fn polygon_contains_test() {
+//         let exterior = LineString(coords(vec![
+//             (0., 0.),
+//             (0., 1.),
+//             (1., 1.),
+//             (1., 0.),
+//             (0., 0.),
+//         ]));
+//         let interiors = vec![LineString(coords(vec![
+//             (0.1, 0.1),
+//             (0.1, 0.9),
+//             (0.9, 0.9),
+//             (0.9, 0.1),
+//             (0.1, 0.1),
+//         ]))];
+//         let p = Polygon::new(exterior.clone(), interiors.clone());
+//
+//         assert_eq!(p.exterior(), &exterior);
+//         assert_eq!(p.interiors(), interiors.as_slice());
+//
+//         let geom: GGeom = (&p).try_into().unwrap();
+//
+//         assert!(geom.contains(&geom).unwrap());
+//         assert!(!geom.contains(&(&exterior).try_into().unwrap()).unwrap());
+//
+//         assert!(geom.covers(&(&exterior).try_into().unwrap()).unwrap());
+//         assert!(geom.touches(&(&exterior).try_into().unwrap()).unwrap());
+//     }
+//
+//     #[test]
+//     fn multipolygon_contains_test() {
+//         let exterior = LineString(coords(vec![
+//             (0., 0.),
+//             (0., 1.),
+//             (1., 1.),
+//             (1., 0.),
+//             (0., 0.),
+//         ]));
+//         let interiors = vec![LineString(coords(vec![
+//             (0.1, 0.1),
+//             (0.1, 0.9),
+//             (0.9, 0.9),
+//             (0.9, 0.1),
+//             (0.1, 0.1),
+//         ]))];
+//         let p = Polygon::new(exterior, interiors);
+//         let mp = MultiPolygon(vec![p.clone()]);
+//
+//         let geom: GGeom = (&mp).try_into().unwrap();
+//
+//         assert!(geom.contains(&geom).unwrap());
+//         assert!(geom.contains(&(&p).try_into().unwrap()).unwrap());
+//     }
+//
+//     #[test]
+//     fn incorrect_multipolygon_test() {
+//         let exterior = LineString(coords(vec![(0., 0.)]));
+//         let interiors = vec![];
+//         let p = Polygon::new(exterior, interiors);
+//         let mp = MultiPolygon(vec![p.clone()]);
+//
+//         let geom = (&mp).try_into();
+//
+//         assert!(geom.is_err());
+//     }
+//
+//     #[test]
+//     fn incorrect_polygon_not_closed() {
+//         // even if the polygon is not closed we can convert it to geos (we close it)
+//         let exterior = LineString(coords(vec![
+//             (0., 0.),
+//             (0., 2.),
+//             (2., 2.),
+//             (2., 0.),
+//             (0., 0.),
+//         ]));
+//         let interiors = vec![LineString(coords(vec![
+//             (0., 0.),
+//             (0., 1.),
+//             (1., 1.),
+//             (1., 0.),
+//             (0., 10.),
+//         ]))];
+//         let p = Polygon::new(exterior, interiors);
+//         let mp = MultiPolygon(vec![p]);
+//
+//         let _g = (&mp).try_into().unwrap(); // no error
+//     }
+//
+//     /// a linear ring can be empty
+//     #[test]
+//     fn empty_linear_ring() {
+//         let ls = LineString(vec![]);
+//         let geom: GGeom = LineRing(&ls).try_into().unwrap();
+//
+//         assert!(geom.is_valid());
+//         assert!(geom.is_ring().unwrap());
+//         assert_eq!(geom.get_coord_seq().unwrap().size().unwrap(), 0);
+//     }
+//
+//     /// a linear ring should have at least 3 elements
+//     #[test]
+//     fn one_elt_linear_ring() {
+//         let ls = LineString(coords(vec![(0., 0.)]));
+//         let geom: Result<GGeom, _> = LineRing(&ls).try_into();
+//         let error = geom.err().unwrap();
+//         assert_eq!(format!("{}", error), "Invalid geometry, impossible to create a LinearRing, A LinearRing must have at least 3 coordinates".to_string());
+//     }
+//
+//     /// a linear ring should have at least 3 elements
+//     #[test]
+//     fn two_elt_linear_ring() {
+//         let ls = LineString(coords(vec![(0., 0.), (0., 1.)]));
+//         let geom: Result<GGeom, _> = LineRing(&ls).try_into();
+//         let error = geom.err().unwrap();
+//         assert_eq!(format!("{}", error), "Invalid geometry, impossible to create a LinearRing, A LinearRing must have at least 3 coordinates".to_string());
+//     }
+//
+//     /// an unclosed linearring is valid since we close it before giving it to geos
+//     #[test]
+//     fn unclosed_linear_ring() {
+//         let ls = LineString(coords(vec![(0., 0.), (0., 1.), (1., 2.)]));
+//         let geom: GGeom = LineRing(&ls).try_into().unwrap();
+//
+//         assert!(geom.is_valid());
+//         assert!(geom.is_ring().unwrap());
+//         assert_eq!(geom.get_coord_seq().unwrap().size().unwrap(), 4);
+//     }
+//
+//     /// a bit tricky
+//     /// a ring should have at least 3 points.
+//     /// in the case of a closed ring with only element eg:
+//     ///
+//     /// let's take a point list: [p1, p2, p1]
+//     ///
+//     /// p1 ----- p2
+//     ///  ^-------|
+//     ///
+//     /// we consider it like a 3 points not closed ring (with the 2 last elements being equals...)
+//     ///
+//     /// shapely (the python geos wrapper) considers that too
+//     #[test]
+//     fn closed_2_points_linear_ring() {
+//         let ls = LineString(coords(vec![(0., 0.), (0., 1.), (1., 1.)]));
+//         let geom: GGeom = LineRing(&ls).try_into().unwrap();
+//
+//         assert!(geom.is_valid());
+//         assert!(geom.is_ring().expect("is_ring failed"));
+//         assert_eq!(geom.get_coord_seq().unwrap().size().unwrap(), 4);
+//     }
+//
+//     /// a linear ring can be empty
+//     #[test]
+//     fn good_linear_ring() {
+//         let ls = LineString(coords(vec![(0., 0.), (0., 1.), (1., 2.), (0., 0.)]));
+//         let geom: GGeom = LineRing(&ls).try_into().unwrap();
+//
+//         assert!(geom.is_valid());
+//         assert!(geom.is_ring().unwrap());
+//         assert_eq!(geom.get_coord_seq().unwrap().size().unwrap(), 4);
+//     }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ extern crate num;
 extern crate geo_types;
 #[cfg(any(feature = "geo", feature = "dox"))]
 extern crate wkt;
+#[cfg(all(feature = "json"))]
+extern crate geojson;
 extern crate geos_sys;
 
 #[cfg(all(feature = "geo", test))]
@@ -64,6 +66,8 @@ mod coord_seq;
 mod error;
 #[cfg(any(feature = "geo", feature = "dox"))]
 pub mod from_geo;
+#[cfg(all(feature = "json"))]
+pub mod from_geojson;
 mod geometry;
 mod prepared_geometry;
 #[cfg(any(feature = "geo", feature = "dox"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ mod geometry;
 mod prepared_geometry;
 #[cfg(any(feature = "geo", feature = "dox"))]
 pub mod to_geo;
+#[cfg(all(feature = "json"))]
+pub mod to_geojson;
 pub use error::{
     Error,
     GResult,

--- a/src/test.rs
+++ b/src/test.rs
@@ -144,6 +144,22 @@ mod test {
         );
     }
 
+    #[test]
+    fn test_get_geometry_n() {
+        let multilinestring = Geometry::new_from_wkt("MULTILINESTRING ((1 1, 10 50, 20 25), (0 0, 7 7, 45 50, 100 100))").unwrap();
+        let l0 = multilinestring.get_geometry_n(0).unwrap();
+        let l1 = multilinestring.get_geometry_n(1).unwrap();
+
+        assert_eq!(
+            l0.to_wkt_precision(0),
+            Ok("LINESTRING (1 1, 10 50, 20 25)".to_owned()),
+        );
+        assert_eq!(
+            l1.to_wkt_precision(0),
+            Ok("LINESTRING (0 0, 7 7, 45 50, 100 100)".to_owned()),
+        );
+    }
+
     fn assert_almost_eq(a: f64, b: f64) {
         let f: f64 = a / b;
         assert!(f < 1.0001);

--- a/src/to_geojson.rs
+++ b/src/to_geojson.rs
@@ -8,7 +8,6 @@ pub trait TryInto<T> {
     fn try_into(self) -> Result<T, Self::Err>;
 }
 
-
 fn coords_seq_to_vec_position(cs: &CoordSeq) -> GResult<Vec<Vec<f64>>> {
     let n_coords = cs.size()?;
     let mut coords = Vec::with_capacity(n_coords);

--- a/src/to_geojson.rs
+++ b/src/to_geojson.rs
@@ -1,0 +1,145 @@
+use crate::{CoordSeq, Geometry as GGeom, GeometryTypes};
+use error::{Error, GResult};
+use geojson::{Geometry, Value};
+// use std::convert::TryInto;
+
+
+pub trait TryInto<T> {
+    type Err;
+    fn try_into(self) -> Result<T, Self::Err>;
+}
+
+
+fn coords_seq_to_vec_position(cs: &CoordSeq) -> GResult<Vec<Vec<f64>>> {
+    let n_coords = cs.size()?;
+    let mut coords = Vec::with_capacity(n_coords);
+    for i in 0..n_coords {
+        coords.push(vec![
+            cs.get_x(i)?,
+            cs.get_y(i)?,
+        ]);
+    }
+    Ok(coords)
+}
+
+impl<'a> TryInto<Geometry> for GGeom<'a> {
+    type Err = Error;
+
+    fn try_into(self) -> Result<Geometry, Self::Err> {
+        let _type = self.geometry_type();
+        match _type {
+            GeometryTypes::Point => {
+                let coord_seq = self.get_coord_seq()?;
+                Ok(Geometry::new(
+                    Value::Point(
+                        vec![
+                            coord_seq.get_x(0)?,
+                            coord_seq.get_y(0)?,
+                        ]
+                    )
+                ))
+            },
+            GeometryTypes::MultiPoint => {
+                let n_pts = self.get_num_geometries()?;
+                let mut coords = Vec::with_capacity(n_pts);
+                for i in 0..n_pts {
+                    let coord_seq = self.get_geometry_n(i)?.get_coord_seq()?;
+                    coords.push(vec![
+                        coord_seq.get_x(0)?,
+                        coord_seq.get_y(0)?,
+                    ]);
+                }
+                Ok(Geometry::new(Value::MultiPoint(coords)))
+            },
+            GeometryTypes::LineString => {
+                let cs = self.get_coord_seq()?;
+                let coords = coords_seq_to_vec_position(&cs)?;
+                Ok(Geometry::new(Value::LineString(coords)))
+            },
+            GeometryTypes::MultiLineString => {
+                let n_lines = self.get_num_geometries()?;
+                let mut result_lines = Vec::with_capacity(n_lines);
+                for i in 0..n_lines {
+                    let cs = self.get_geometry_n(i)?.get_coord_seq()?;
+                    result_lines.push(coords_seq_to_vec_position(&(cs))?);
+                }
+                Ok(Geometry::new(Value::MultiLineString(result_lines)))
+            },
+            GeometryTypes::Polygon => {
+                let nb_interiors = self.get_num_interior_rings()?;
+
+                let mut rings = Vec::with_capacity(nb_interiors + 1usize);
+                // Exterior ring to coordinates
+                rings.push(coords_seq_to_vec_position(&(
+                    self.get_exterior_ring()?.get_coord_seq()?))?);
+                // Interior rings to coordinates
+                for ix_interior in 0..nb_interiors {
+                    rings.push(coords_seq_to_vec_position(
+                        &(self.get_interior_ring_n(ix_interior as u32)?.get_coord_seq()?))?);
+                }
+                Ok(Geometry::new(Value::Polygon(rings)))
+            },
+            GeometryTypes::MultiPolygon => {
+                let n_polygs = self.get_num_geometries()?;
+                let mut result_polygs = Vec::with_capacity(n_polygs);
+                for i in 0..n_polygs {
+                    let polyg = self.get_geometry_n(i)?;
+                    let nb_interiors = polyg.get_num_interior_rings()?;
+
+                    let mut rings = Vec::with_capacity(nb_interiors + 1usize);
+                    // Exterior ring to coordinates
+                    rings.push(coords_seq_to_vec_position(&(
+                        self.get_exterior_ring()?.get_coord_seq()?))?);
+                    // Interior rings to coordinates
+                    for ix_interior in 0..nb_interiors {
+                        rings.push(coords_seq_to_vec_position(
+                            &(self.get_interior_ring_n(ix_interior as u32)?.get_coord_seq()?))?);
+                    }
+                    result_polygs.push(rings);
+                }
+                Ok(Geometry::new(Value::MultiPolygon(result_polygs)))
+            },
+            GeometryTypes::GeometryCollection => {
+                let n_geoms = self.get_num_geometries()?;
+                let mut result_geoms = Vec::with_capacity(n_geoms);
+                for i in 0..n_geoms {
+                    let g = self.get_geometry_n(i)?;
+                    let geojsongeom: Geometry = g.try_into()?;
+                    result_geoms.push(geojsongeom);
+                }
+                Ok(Geometry::new(Value::GeometryCollection(result_geoms)))
+            },
+            _ => unreachable!()
+        }
+    }
+}
+
+// #[cfg(test)]
+// mod test {
+//     use super::GGeom;
+//     use from_geo::TryInto;
+//     use geo_types::{Coordinate, Geometry, LineString, Ok(MultiPolygon, Polygon};
+//
+//     fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
+//         tuples.into_iter().map(Coordinate::from).collect()
+//     }
+//
+//     #[test]
+//     fn geom_to_geo_polygon() {
+//         let poly = "MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))";
+//         let poly = GGeom::new_from_wkt(poly).unwrap();
+//
+//         let geo_polygon: Geometry<f64> = poly.try_into().unwrap();
+//
+//         let exterior = LineString(coords(vec![
+//             (0., 0.),
+//             (0., 1.),
+//             (1., 1.),
+//             (1., 0.),
+//             (0., 0.),
+//         ]));
+//         let expected_poly = MultiPolygon(vec![Polygon::new(exterior, vec![])]);
+//         let expected: Geometry<_> = expected_poly.into();
+//         assert_eq!(expected, geo_polygon);
+//     }
+// }


### PR DESCRIPTION
This PR propose to add a `json` feature flag to handle the conversion from / to [geojson](https://github.com/georust/geojson) crate (instead of having to create [geo-type](https://github.com/georust/geo) geometries - themselves relying on WKT - to do it).