### PR TITLE
Try into

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num = "0.2"
 c_vec = "1.3"
 geojson = { version = "0.17", optional = true }
 geo-types = { version = "0.6", optional = true }
-wkt = { git = "https://github.com/riendegris/wkt.git", branch = "update_dependencies", optional = true }
+wkt = { version = "0.8", optional = true }
 geos-sys = "1.0"
 doc-comment = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ libc = "0.2"
 num = "0.2"
 c_vec = "1.3"
 geojson = { version = "0.17", optional = true }
-geo-types = { version = "0.4", optional = true }
-wkt = { version = "0.5", optional = true }
+geo-types = { version = "0.6", optional = true }
+wkt = { git = "https://github.com/riendegris/wkt.git", branch = "update_dependencies", optional = true }
 geos-sys = "1.0"
 doc-comment = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ c_vec = "1.3"
 geojson = { version = "0.17", optional = true }
 geo-types = { version = "0.6", optional = true }
 wkt = { version = "0.8", optional = true }
-geos-sys = "1.0"
+geos-sys = { git = "https://github.com/georust/geos-sys", branch = "fix-fn" }
 doc-comment = "0.3"
 
 [package.metadata.docs.rs]

--- a/examples/from_geo.rs
+++ b/examples/from_geo.rs
@@ -6,6 +6,8 @@ extern crate geos;
 use geo_types::{Coordinate, LineString, Polygon};
 #[cfg(feature = "geo")]
 use geos::{Error, Geometry};
+#[cfg(feature = "geo")]
+use std::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "geo")]
 fn fun() -> Result<(), Error> {

--- a/examples/from_geo.rs
+++ b/examples/from_geo.rs
@@ -4,10 +4,11 @@ extern crate geos;
 
 #[cfg(feature = "geo")]
 use geo_types::{Coordinate, LineString, Polygon};
-#[cfg(feature = "geo")]
-use geos::from_geo::TryInto;
+// #[cfg(feature = "geo")]
+// use geos::from_geo::TryInto;
 #[cfg(feature = "geo")]
 use geos::{Error, Geometry};
+use std::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "geo")]
 fn fun() -> Result<(), Error> {
@@ -30,7 +31,7 @@ fn fun() -> Result<(), Error> {
     assert_eq!(p.exterior(), &exterior);
     assert_eq!(p.interiors(), interiors.as_slice());
 
-    let geom: Geometry = (&p).try_into()?;
+    let geom = Geometry::try_from(&p)?;
 
     assert!(geom.contains(&geom)?);
     assert!(!geom.contains(&(&exterior).try_into()?)?);
@@ -45,8 +46,7 @@ fn main() {
     fun().unwrap();
 }
 
-
 #[cfg(not(feature = "geo"))]
 fn main() {
-    eprintln!("You need to enable the \"geo\" feature to run this example!", );
+    eprintln!("You need to enable the \"geo\" feature to run this example!",);
 }

--- a/examples/from_geo.rs
+++ b/examples/from_geo.rs
@@ -4,11 +4,8 @@ extern crate geos;
 
 #[cfg(feature = "geo")]
 use geo_types::{Coordinate, LineString, Polygon};
-// #[cfg(feature = "geo")]
-// use geos::from_geo::TryInto;
 #[cfg(feature = "geo")]
 use geos::{Error, Geometry};
-use std::convert::{TryFrom, TryInto};
 
 #[cfg(feature = "geo")]
 fn fun() -> Result<(), Error> {
@@ -48,5 +45,5 @@ fn main() {
 
 #[cfg(not(feature = "geo"))]
 fn main() {
-    eprintln!("You need to enable the \"geo\" feature to run this example!",);
+    eprintln!("You need to enable the \"geo\" feature to run this example!");
 }

--- a/src/coord_seq.rs
+++ b/src/coord_seq.rs
@@ -404,7 +404,15 @@ impl<'a> CoordSeq<'a> {
         assert!(self.nb_dimensions > ordinate);
 
         unsafe {
-            GEOSCoordSeq_getOrdinate_r(self.get_raw_context(), self.as_raw(), line as _, ordinate)
+            let mut ord = 0.;
+            GEOSCoordSeq_getOrdinate_r(
+                self.get_raw_context(),
+                self.as_raw(),
+                line as _,
+                ordinate,
+                &mut ord,
+            );
+            ord
         }
     }
 

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -1,10 +1,8 @@
 use crate::{CoordDimensions, CoordSeq, Geometry as GGeom};
 use error::Error;
 use geo_types::{Coordinate, LineString, MultiPolygon, Point, Polygon};
-use std;
 use std::borrow::Borrow;
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 
 fn create_coord_seq<'a, 'b, It>(points: It, len: usize) -> Result<CoordSeq<'b>, Error>
 where

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -84,11 +84,13 @@ impl<'a, 'b> TryFrom<&'a LineRing<'b>> for GGeom<'b> {
         }
 
         let mut points = linering.0.points_iter();
-        let first = points.next().expect("At least one point"); // This expect is OK because we
-                                                                // took care of the case where there is no points
-        let last = points.last().expect("No last point"); // This expect is OK too, because if there is
-                                                          // at least one point, there is at least 3 points
-                                                          // because of the constraint above.
+
+        // The following expect is OK because we took care of the case where there is no points
+        let first = points.next().expect("At least one point");
+
+        // This expect is OK too, because if there is at least one point, there is at least 3 points
+        // because of the constraint above.
+        let last = points.last().expect("No last point");
 
         // if the geom is not closed we close it
         let is_closed = nb_points > 0 && first == last;

--- a/src/to_geo.rs
+++ b/src/to_geo.rs
@@ -1,14 +1,14 @@
 use crate::Geometry as GGeom;
 use error::Error;
-use from_geo::TryInto;
 use geo_types::Geometry;
+use std::convert::TryInto;
 use wkt;
 use wkt::conversion::try_into_geometry;
 
 impl<'a> TryInto<Geometry<f64>> for GGeom<'a> {
-    type Err = Error;
+    type Error = Error;
 
-    fn try_into(self) -> Result<Geometry<f64>, Self::Err> {
+    fn try_into(self) -> Result<Geometry<f64>, Self::Error> {
         // This is a first draft, it's very inefficient, we use wkt as a pivot format to
         // translate the geometry.
         // We should at least use wkb, or even better implement a direct translation
@@ -16,7 +16,7 @@ impl<'a> TryInto<Geometry<f64>> for GGeom<'a> {
         let wkt_obj = wkt::Wkt::from_str(&wkt_str)
             .map_err(|e| Error::ConversionError(format!("impossible to read wkt: {}", e)))?;
 
-        let o: &wkt::Geometry = wkt_obj
+        let o: &wkt::Geometry<f64> = wkt_obj
             .items
             .iter()
             .next()
@@ -30,8 +30,8 @@ impl<'a> TryInto<Geometry<f64>> for GGeom<'a> {
 #[cfg(test)]
 mod test {
     use super::GGeom;
-    use from_geo::TryInto;
     use geo_types::{Coordinate, Geometry, LineString, MultiPolygon, Polygon};
+    use std::convert::TryInto;
 
     fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
         tuples.into_iter().map(Coordinate::from).collect()

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -1,8 +1,8 @@
 use crate::Geometry as GGeom;
 use error::Error;
-use from_geo::TryInto;
 use geo_types::{Geometry, GeometryCollection, Point, Polygon};
 use std::borrow::Borrow;
+use std::convert::TryInto;
 
 /// Available using the `geo` feature.
 pub fn compute_voronoi<T: Borrow<Point<f64>>>(
@@ -23,8 +23,8 @@ pub fn compute_voronoi<T: Borrow<Point<f64>>>(
         .and_then(|gc: GeometryCollection<f64>| {
             gc.0.into_iter()
                 .map(|g| {
-                    g.into_polygon()
-                        .ok_or(Error::ConversionError("invalid inner geometry type".into()))
+                    g.try_into()
+                        .map_err(|_| Error::ConversionError("invalid inner geometry type".into()))
                 })
                 .collect()
         })


### PR DESCRIPTION
This work follows my effort to standardize mimirsbrunn dependencies on a unique version of geo_types (0.6)

I've noticed the comment `// define our own TryInto while the std trait is not stable` and felt it was time to move on... So I've removed this comment and the trait definition, and tried to use `std::convert::TryFrom` instead.

There is one test that's not working... closed_2_points_linear_ring. I don't understand what needs to be tested, and, from the little I read, it seems the diagram did not match what the code was doing.... So this point (pun intended) needs a bit more work.