### PR TITLE
Fixed issue causing build to break on ARM.

### DIFF
--- a/src/prepared_geometry.rs
+++ b/src/prepared_geometry.rs
@@ -90,7 +90,7 @@ impl<'a> PreparedGeometry<'a> {
         let ret_val = unsafe {
             GEOSPreparedContains_r(self.get_raw_context(), self.as_raw(), other.as_raw())
         };
-        check_geos_predicate(ret_val, PredicateType::PreparedContains)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedContains)
     }
 
     /// Returns `true` if every point of the `other` geometry is inside self's interior.
@@ -114,7 +114,7 @@ impl<'a> PreparedGeometry<'a> {
         let ret_val = unsafe {
             GEOSPreparedContainsProperly_r(self.get_raw_context(), self.as_raw(), other.as_raw())
         };
-        check_geos_predicate(ret_val, PredicateType::PreparedContainsProperly)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedContainsProperly)
     }
 
     /// Returns `true` if no point of `self` is outside of `other`.
@@ -143,7 +143,7 @@ impl<'a> PreparedGeometry<'a> {
         let ret_val = unsafe {
             GEOSPreparedCoveredBy_r(self.get_raw_context(), self.as_raw(), other.as_raw())
         };
-        check_geos_predicate(ret_val, PredicateType::PreparedCoveredBy)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedCoveredBy)
     }
 
     /// Returns `true` if no point of `other` is outside of `self`.
@@ -171,7 +171,7 @@ impl<'a> PreparedGeometry<'a> {
     pub fn covers<'b, G: Geom<'b>>(&self, other: &G) -> GResult<bool> {
         let ret_val =
             unsafe { GEOSPreparedCovers_r(self.get_raw_context(), self.as_raw(), other.as_raw()) };
-        check_geos_predicate(ret_val, PredicateType::PreparedCovers)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedCovers)
     }
 
     /// Returns `true` if `self` and `other` have at least one interior into each other.
@@ -192,7 +192,7 @@ impl<'a> PreparedGeometry<'a> {
     pub fn crosses<'b, G: Geom<'b>>(&self, other: &G) -> GResult<bool> {
         let ret_val =
             unsafe { GEOSPreparedCrosses_r(self.get_raw_context(), self.as_raw(), other.as_raw()) };
-        check_geos_predicate(ret_val, PredicateType::PreparedCrosses)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedCrosses)
     }
 
     /// Returns `true` if `self` doesn't:
@@ -223,7 +223,7 @@ impl<'a> PreparedGeometry<'a> {
         let ret_val = unsafe {
             GEOSPreparedDisjoint_r(self.get_raw_context(), self.as_raw(), other.as_raw())
         };
-        check_geos_predicate(ret_val, PredicateType::PreparedDisjoint)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedDisjoint)
     }
 
     /// Returns `true` if `self` shares any portion of space with `other`. So if any of this is
@@ -257,7 +257,7 @@ impl<'a> PreparedGeometry<'a> {
         let ret_val = unsafe {
             GEOSPreparedIntersects_r(self.get_raw_context(), self.as_raw(), other.as_raw())
         };
-        check_geos_predicate(ret_val, PredicateType::PreparedIntersects)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedIntersects)
     }
 
     /// Returns `true` if `self` spatially overlaps `other`.
@@ -289,7 +289,7 @@ impl<'a> PreparedGeometry<'a> {
         let ret_val = unsafe {
             GEOSPreparedOverlaps_r(self.get_raw_context(), self.as_raw(), other.as_raw())
         };
-        check_geos_predicate(ret_val, PredicateType::PreparedOverlaps)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedOverlaps)
     }
 
     /// Returns `true` if the only points in common between `self` and `other` lie in the union of
@@ -316,7 +316,7 @@ impl<'a> PreparedGeometry<'a> {
     pub fn touches<'b, G: Geom<'b>>(&self, other: &G) -> GResult<bool> {
         let ret_val =
             unsafe { GEOSPreparedTouches_r(self.get_raw_context(), self.as_raw(), other.as_raw()) };
-        check_geos_predicate(ret_val, PredicateType::PreparedTouches)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedTouches)
     }
 
     /// Returns `true` if `self` is completely inside `other`.
@@ -345,7 +345,7 @@ impl<'a> PreparedGeometry<'a> {
     pub fn within<'b, G: Geom<'b>>(&self, other: &G) -> GResult<bool> {
         let ret_val =
             unsafe { GEOSPreparedWithin_r(self.get_raw_context(), self.as_raw(), other.as_raw()) };
-        check_geos_predicate(ret_val, PredicateType::PreparedWithin)
+        check_geos_predicate(ret_val as _, PredicateType::PreparedWithin)
     }
 }
 


### PR DESCRIPTION
```
#20 199.4    Compiling geos v8.0.0
#20 202.9 error[E0308]: mismatched types
#20 202.9   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:93:30
#20 202.9    |
#20 202.9 93 |         check_geos_predicate(ret_val, PredicateType::PreparedContains)
#20 202.9    |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9    |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9    |
#20 202.9 93 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedContains)
#20 202.9    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:117:30
#20 202.9     |
#20 202.9 117 |         check_geos_predicate(ret_val, PredicateType::PreparedContainsProperly)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 117 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedContainsProperly)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:146:30
#20 202.9     |
#20 202.9 146 |         check_geos_predicate(ret_val, PredicateType::PreparedCoveredBy)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 146 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedCoveredBy)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:174:30
#20 202.9     |
#20 202.9 174 |         check_geos_predicate(ret_val, PredicateType::PreparedCovers)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 174 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedCovers)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:195:30
#20 202.9     |
#20 202.9 195 |         check_geos_predicate(ret_val, PredicateType::PreparedCrosses)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 195 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedCrosses)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:226:30
#20 202.9     |
#20 202.9 226 |         check_geos_predicate(ret_val, PredicateType::PreparedDisjoint)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 226 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedDisjoint)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:260:30
#20 202.9     |
#20 202.9 260 |         check_geos_predicate(ret_val, PredicateType::PreparedIntersects)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 260 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedIntersects)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:292:30
#20 202.9     |
#20 202.9 292 |         check_geos_predicate(ret_val, PredicateType::PreparedOverlaps)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 292 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedOverlaps)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:319:30
#20 202.9     |
#20 202.9 319 |         check_geos_predicate(ret_val, PredicateType::PreparedTouches)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 319 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedTouches)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 202.9 error[E0308]: mismatched types
#20 202.9    --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/geos-8.0.0/src/prepared_geometry.rs:348:30
#20 202.9     |
#20 202.9 348 |         check_geos_predicate(ret_val, PredicateType::PreparedWithin)
#20 202.9     |                              ^^^^^^^ expected `i8`, found `u8`
#20 202.9     |
#20 202.9 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
#20 202.9     |
#20 202.9 348 |         check_geos_predicate(ret_val.try_into().unwrap(), PredicateType::PreparedWithin)
#20 202.9     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#20 202.9 
#20 203.4 error: aborting due to 10 previous errors
#20 203.4 
#20 203.5 For more information about this error, try `rustc --explain E0308`.
#20 203.5 error: could not compile `geos`
#20 203.5 
#20 203.5 To learn more, run the command again with --verbose.
#20 203.5 warning: build failed, waiting for other jobs to finish...
#20 270.4 error: build failed
```