### PR TITLE
Implement std::error::Error for geos::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     GenericError(String),
 }
 
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {


### PR DESCRIPTION
Geos is excellent binding library, but there is one inconvenience.

When we try to catch the error returned from geos in Boxed error trait or anyhow::Error with `?` operator, it fails to compile, e.g.

```rust
use geos::Geom;

fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
    let gg1 = geos::Geometry::new_from_wkt("POLYGON ((0 0, 0 5, 6 6, 6 0, 0 0))")?;
    let gg2 = geos::Geometry::new_from_wkt("POLYGON ((1 1, 1 3, 5 5, 5 1, 1 1))")?;
    let gg3 = gg1.difference(&gg2)?;
    assert_eq!(
        gg3.to_wkt_precision(0).expect("to_wkt failed"),
        "POLYGON ((0 0, 0 5, 6 6, 6 0, 0 0), (1 1, 5 1, 5 5, 1 3, 1 1))",
    );

    Ok(())
}
```

```rust
use geos::Geom;
use anyhow::Result;

fn main() -> Result<()> {
    let gg1 = geos::Geometry::new_from_wkt("POLYGON ((0 0, 0 5, 6 6, 6 0, 0 0))")?;
    let gg2 = geos::Geometry::new_from_wkt("POLYGON ((1 1, 1 3, 5 5, 5 1, 1 1))")?;
    let gg3 = gg1.difference(&gg2)?;
    assert_eq!(
        gg3.to_wkt_precision(0).expect("to_wkt failed"),
        "POLYGON ((0 0, 0 5, 6 6, 6 0, 0 0), (1 1, 5 1, 5 5, 1 3, 1 1))",
    );

    Ok(())
}
```

because `geos::Error` does not implement `std::error::Error`.

It would be much more convenient if we can catch errors like this, especially when mixed with other crates' errors.

It is very easy to fix on library side by putting one line like below but it's not possible to fix on user code because of orphan rule.

```rust
impl std::error::Error for Error {}
```