### PR TITLE
TST: Update tests to pass on GEOS 3.6 - 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-geos
-====
+# geos
 
 Rust bindings for [GEOS](https://trac.osgeo.org/geos/) C API.
 
@@ -23,7 +22,9 @@ let gg1 = geos::Geometry::new_from_wkt("POLYGON ((0 0, 0 5, 6 6, 6 0, 0 0))")
                          .expect("invalid WKT");
 let gg2 = geos::Geometry::new_from_wkt("POLYGON ((1 1, 1 3, 5 5, 5 1, 1 1))")
                          .expect("invalid WKT");
-let gg3 = gg1.difference(&gg2).expect("difference failed");
+let mut gg3 = gg1.difference(&gg2).expect("difference failed");
+// normalize is only used for consistent ordering of vertices
+gg3.normalize().expect("normalize failed");
 assert_eq!(
     gg3.to_wkt_precision(0).expect("to_wkt failed"),
     "POLYGON ((0 0, 0 5, 6 6, 6 0, 0 0), (1 1, 5 1, 5 5, 1 3, 1 1))",

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -89,11 +89,12 @@ pub trait Geom<'a>:
     /// ```
     /// use geos::{Geom, Geometry};
     ///
-    /// let geom = Geometry::new_from_wkt("POLYGON((0 0, 1 1, 1 2, 1 1, 0 0))")
+    /// // Bowtie polygon with self-intersection
+    /// let geom = Geometry::new_from_wkt("POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))")
     ///                     .expect("Invalid geometry");
     /// assert_eq!(
     ///     geom.is_valid_reason(),
-    ///     Ok("Self-intersection[0 0]".to_owned()),
+    ///     Ok("Self-intersection[1 1]".to_owned()),
     /// );
     /// ```
     fn is_valid_reason(&self) -> GResult<String>;
@@ -612,7 +613,8 @@ pub trait Geom<'a>:
     /// let geom = Geometry::create_multipolygon(vec![geom1, geom2])
     ///                     .expect("Failed to build multipolygon");
     ///
-    /// let union_geom = geom.unary_union().expect("unary_union failed");
+    /// let mut union_geom = geom.unary_union().expect("unary_union failed");
+    /// union_geom.normalize().expect("normalize failed");
     ///
     /// assert_eq!(
     ///     union_geom.to_wkt_precision(1).unwrap(),
@@ -627,21 +629,13 @@ pub trait Geom<'a>:
     /// ```
     /// use geos::{Geom, Geometry};
     ///
-    /// let input = Geometry::new_from_wkt("MULTIPOINT((100 200), (105 202), (110 200), (140 230),
-    ///                                                (210 240), (220 190), (170 170), (170 260),
-    ///                                                (213 245), (220 190))")
+    /// let input = Geometry::new_from_wkt("MULTIPOINT(2 2, 4 2)")
     ///                   .expect("Invalid geometry");
     /// let mut expected = Geometry::new_from_wkt(
-    ///     "GEOMETRYCOLLECTION(POLYGON ((-20 50, -20 380, -3.75 380, 105 235, 105 115, 77.14285714285714 50, -20 50)),\
-    ///                          POLYGON ((247 50, 77.14285714285714 50, 105 115, 145 195, 178.33333333333334 211.66666666666666, 183.51851851851853 208.7037037037037, 247 50)),\
-    ///                          POLYGON ((-3.75 380, 20.000000000000007 380, 176.66666666666666 223.33333333333334, 178.33333333333334 211.66666666666666, 145 195, 105 235, -3.75 380)),\
-    ///                          POLYGON ((105 115, 105 235, 145 195, 105 115)),\
-    ///                          POLYGON ((20.000000000000007 380, 255 380, 176.66666666666666 223.33333333333334, 20.000000000000007 380)),\
-    ///                          POLYGON ((255 380, 340 380, 340 240, 183.51851851851853 208.7037037037037, 178.33333333333334 211.66666666666666, 176.66666666666666 223.33333333333334, 255 380)),\
-    ///                          POLYGON ((340 240, 340 50, 247 50, 183.51851851851853 208.7037037037037, 340 240)))")
-    ///                             .expect("Invalid geometry");
+    ///     "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 4, 3 4, 3 0, 0 0)), POLYGON ((6 4, 6 0, 3 0, 3 4, 6 4)))")
+    ///     .expect("Invalid geometry");
     ///
-    /// let mut voronoi = input.voronoi(None::<&Geometry>, 6., false)
+    /// let mut voronoi = input.voronoi(None::<&Geometry>, 0., false)
     ///                        .expect("voronoi failed");
     ///
     /// expected.normalize().expect("normalize failed");
@@ -2434,22 +2428,15 @@ impl<'a> Geometry<'a> {
     /// ```
     /// use geos::{Geom, Geometry};
     ///
-    /// let geom = Geometry::new_from_wkt("POINT(100 90)").expect("Invalid geometry");
-    /// let small_geom = geom.buffer(25., 8).expect("buffer failed");
-    /// let big_geom = geom.buffer(50., 8).expect("buffer failed");
+    /// let geom = Geometry::new_from_wkt("GEOMETRYCOLLECTION( \
+    ///                                     POLYGON((0 0, 4 0, 4 4, 0 4, 0 0)), \
+    ///                                     POLYGON((1 1, 1 3, 3 3, 3 1, 1 1)))")
+    ///             .expect("Invalid geometry");
     ///
-    /// let union_geom = small_geom.union(&big_geom).expect("union failed");
-    /// let build_area_geom = union_geom.build_area().expect("build_area failed");
-    ///
-    /// // Looks like a donut.
-    /// assert_eq!(union_geom.to_wkt_precision(1).unwrap(),
-    ///            "POLYGON ((150.0 90.0, 149.0 80.2, 146.2 70.9, 141.6 62.2, 135.4 54.6, \
-    ///                       127.8 48.4, 119.1 43.8, 109.8 41.0, 100.0 40.0, 90.2 41.0, \
-    ///                       80.9 43.8, 72.2 48.4, 64.6 54.6, 58.4 62.2, 53.8 70.9, 51.0 80.2, \
-    ///                       50.0 90.0, 51.0 99.8, 53.8 109.1, 58.4 117.8, 64.6 125.4, \
-    ///                       72.2 131.6, 80.9 136.2, 90.2 139.0, 100.0 140.0, 109.8 139.0, \
-    ///                       119.1 136.2, 127.8 131.6, 135.4 125.4, 141.6 117.8, 146.2 109.1, \
-    ///                       149.0 99.8, 150.0 90.0))");
+    /// let build_area_geom = geom.build_area().expect("build_area failed");
+    /// // Square polygon with square hole.
+    /// assert_eq!(build_area_geom.to_wkt_precision(0).unwrap(),
+    ///            "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0), (1 1, 3 1, 3 3, 1 3, 1 1))");
     /// ```
     #[cfg(any(feature = "v3_8_0", feature = "dox"))]
     pub fn build_area(&self) -> GResult<Geometry<'a>> {

--- a/sys/README.md
+++ b/sys/README.md
@@ -20,6 +20,24 @@ configure GEOS detection (both must be set):
 -   `GEOS_LIB_DIR`
 -   `GEOS_VERSION`
 
+If `GEOS_LIB_DIR` is not also in your system's standard dynamic library search
+path, you may need to add it to the dynamic library search path before
+running the tests or executable produced by `cargo build`.
+
+Linux:
+
+```bash
+LD_LIBRARY_PATH=<path to GEOS>/lib GEOS_LIB_DIR=<path to GEOS>/lib GEOS_VERSION=<version> cargo test
+
+```
+
+MacOS:
+
+```bash
+DYLD_FALLBACK_LIBRARY_PATH=<path to GEOS>/lib GEOS_LIB_DIR=<path to GEOS>/lib GEOS_VERSION=<version> cargo test
+
+```
+
 You can build the included version of GEOS using the `static` feature, which
 will also statically link libgeos to this crate. In order to build GEOS, you
 need to have `cmake` and a C++ compiler. Building GEOS may take several minutes.


### PR DESCRIPTION
This updates and simplifies the tests that were breaking on GEOS > 3.6 so that they run on all versions 3.6 - 3.11.

I understand that some of the doctests use geometires from the PostGIS documentation.  However, these are more complex than necessary for simple examples, so I simplified these down for clarity and to ensure they pass.