### PR TITLE
Upgrade wkt package version to fix a bug involving multipoint.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ num = "0.4"
 c_vec = "2"
 geojson = { version = "0.22", optional = true }
 geo-types = { version = "0.7", optional = true }
-wkt = { version = "0.9", optional = true }
+wkt = { version = "0.10.3", optional = true }
 geos-sys = { path = "sys", version = "2.0.4" }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Without the package upgrade we panic with this error:

`thread 'to_geo::test::geom_to_geo_multipoint' panicked at 'called `Result::unwrap()` on an `Err` value: ConversionError("impossible to read wkt: Missing closing parenthesis for type")', src/to_geo.rs:82:59`