### PR TITLE
Fix 'from_geo' example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ to use all geos algorithms.
 Complete example can be found in `examples/from_geo.rs`
 
 ```rust,ignore
-use geos::from_geo::TryInto;
 use geos::geo_types::{LineString, Coordinate, Polygon};
 
 // first we create a Geo object


### PR DESCRIPTION
This fixes the 'from_geo' example in the README (and so in the doc generated by `cargo doc`, as it includes the README) by removing the `use geos::from_geo::TryInto;` statement (otherwise cargo complains that this trait is private).