### PR TITLE
MNT: Update GEOS source to 3.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,19 @@ let voronoi = compute_voronoi(&points, None, 0., false)
 
 ## Static build
 
-By default, this crate links dynamically. If you want to link statically, use the `static` feature.
+By default, this crate links dynamically to your system-installed GEOS or a
+different version that you configure. See [sys/README.md](./sys/README.md) for
+more information.
+
+If you want to link GEOS statically, use the `static` feature.
+
+The static build uses the GEOS version in the git submodule in`sys/geos-src/source`.
+This is currently GEOS 3.11.2.
+
+You will need to have a build environment supported for the static version of
+GEOS. See [GEOS build instructions](https://libgeos.org/usage/download/#build-from-source)
+for more information but please note that instructions may be for a newer
+version of GEOS than is currently included in the static build.
 
 ## Contributing
 

--- a/geos-sys-bind/README.md
+++ b/geos-sys-bind/README.md
@@ -21,8 +21,9 @@ This crate will attempt to automatically detect your installation of GEOS:
 
 ### 1. Update included version of GEOS
 
-* update the GEOS submodule to the latest available GEOS version
-* update `BUNDLED_GEOS_VERSION` in `sys/build.rs` to match this version
+-   update the GEOS submodule to the latest available GEOS version
+-   update `BUNDLED_GEOS_VERSION` in `sys/build.rs` to match this version
+-   update the version in the top-level README.md static build section
 
 ### 2. Generate new bindings
 
@@ -70,7 +71,6 @@ include!("../prebuilt-bindings/geos_<major>.<minor>.rs");
 ```
 
 NOTE: docs are always generated from the latest version.
-
 
 Update the entry for the previous version to exclude the latest version:
 


### PR DESCRIPTION
This updates the pinned version of GEOS for the `static` feature to 3.11.2 ([changelog](https://libgeos.org/posts/2023-03-16-geos-3-11-2-released/)).

This compiles successfully on GCC-12 and clang-14 (tested on `debian:unstable` Docker container)

/cc @jayvdb