### PR TITLE
Add-descriptive-comment-to-comput_vornoi-function-tolerance-parameter

### DIFF
--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -6,6 +6,10 @@ use std::borrow::Borrow;
 use std::convert::TryInto;
 
 /// Available using the `geo` feature.
+/// About the `tolerance` argument, the underlying C library mentions:
+/// > snapping tolerance to use for improved robustness. A tolerance of 0.0 specifies that no snapping
+/// > will take place. This argument can be finicky and is known to cause the algorithm to fail in
+/// > several cases. If you're using tolerance and getting a failure, try setting it to 0.0.
 pub fn compute_voronoi<T: Borrow<Point<f64>>>(
     points: &[T],
     envelope: Option<&GGeometry>,


### PR DESCRIPTION
Adds a comment describing the tolerance parameter of the compute_voronoi function. This is useful as the parameter is described as finicky by the underlying c library. Having this comment would have saved me a headache.

Open to suggestions on better ways to expose this information.