### PR TITLE
WIP ConstCoordSeq

### DIFF
--- a/src/coord_seq.rs
+++ b/src/coord_seq.rs
@@ -35,7 +35,6 @@ pub struct CoordSeq<'a> {
 pub struct ConstCoordSeq<'a, 'b> {
     pub(crate) ptr: PtrWrap<*const GEOSCoordSequence>,
     pub(crate) original: &'b Geometry<'a>,
-    // pub(crate) context: ContextHandle<'a>,
     nb_dimensions: usize,
     nb_lines: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) mod functions;
 
 pub use buffer_params::{BufferParams, BufferParamsBuilder};
 pub use context_handle::{ContextHandle, HandlerCallback};
-pub use coord_seq::CoordSeq;
+pub use coord_seq::{ConstCoordSeq, CoordSeq};
 #[cfg(any(feature = "v3_6_0", feature = "dox"))]
 pub use enums::Precision;
 pub use enums::{


### PR DESCRIPTION
Closes https://github.com/georust/geos/issues/137

This adds a new struct for `ConstCoordSeq` that contains a const pointer to the GEOS coord seq object.

The ideal API would probably be to have something like the `Geom` trait for coordinate sequences, but I assume that's backwards-incompatible, because users would then also have to import such a trait?

I didn't notice any performance improvement on my relevant benchmark in my geoarrow project, so it's possible I either implemented it wrong or this is such a small performance gain that it's immeasurably small.