### PR TITLE
Update GEOS source to 3.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ more information.
 If you want to link GEOS statically, use the `static` feature.
 
 The static build uses the GEOS version in the git submodule in`sys/geos-src/source`.
-This is currently GEOS 3.11.2.
+This is currently GEOS 3.11.3.
 
 You will need to have a build environment supported for the static version of
 GEOS. See [GEOS build instructions](https://libgeos.org/usage/download/#build-from-source)


### PR DESCRIPTION
Fixes compilation error with clang 16 and gcc 13 (missing 'cstdint' header).