### PR TITLE
fix: get_num_geometries failing on empty geom

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -2009,7 +2009,7 @@ impl$(<$lt>)? Geom for $ty_name$(<$lt>)? {
     fn get_num_geometries(&self) -> GResult<usize> {
         unsafe {
             let ret = GEOSGetNumGeometries_r(self.get_raw_context(), self.as_raw());
-            if ret < 1 {
+            if ret == -1 {
                 Err(Error::GenericError("GEOSGetNumGeometries_r failed".to_owned()))
             } else {
                 Ok(ret as _)


### PR DESCRIPTION
Failed call to `GEOSGetNumGeometries_r` is signaled by -1. Zero on the other hand is valid result when geometry is empty.