### PR TITLE
Tthread-local geos context

### DIFF
--- a/src/buffer_params.rs
+++ b/src/buffer_params.rs
@@ -1,16 +1,12 @@
-use crate::context_handle::PtrWrap;
+use crate::context_handle::{with_context, PtrWrap};
 use crate::enums::CapStyle;
-use crate::{
-    AsRaw, AsRawMut, ContextHandle, ContextHandling, ContextInteractions, Error, GResult, JoinStyle,
-};
+use crate::{AsRaw, AsRawMut, Error, GResult, JoinStyle};
 
 use geos_sys::*;
-use std::sync::Arc;
 
 /// Contains the parameters which describe how a [Geometry](crate::Geometry) buffer should be constructed using [buffer_with_params](crate::Geom::buffer_with_params)
 pub struct BufferParams {
     ptr: PtrWrap<*mut GEOSBufferParams>,
-    context: Arc<ContextHandle>,
 }
 
 /// Build options for a [`BufferParams`] object
@@ -25,16 +21,10 @@ pub struct BufferParamsBuilder {
 
 impl BufferParams {
     pub fn new() -> GResult<BufferParams> {
-        match ContextHandle::init_e(Some("BufferParams::new")) {
-            Ok(context) => unsafe {
-                let ptr = GEOSBufferParams_create_r(context.as_raw());
-                Ok(BufferParams {
-                    ptr: PtrWrap(ptr),
-                    context: Arc::new(context),
-                })
-            },
-            Err(e) => Err(e),
-        }
+        with_context(|ctx| unsafe {
+            let ptr = GEOSBufferParams_create_r(ctx.as_raw());
+            Ok(BufferParams { ptr: PtrWrap(ptr) })
+        })
     }
 
     pub fn builder() -> BufferParamsBuilder {
@@ -43,9 +33,9 @@ impl BufferParams {
 
     /// Specifies the end cap style of the generated buffer.
     pub fn set_end_cap_style(&mut self, style: CapStyle) -> GResult<()> {
-        unsafe {
+        with_context(|ctx| unsafe {
             let ret = GEOSBufferParams_setEndCapStyle_r(
-                self.get_raw_context(),
+                ctx.as_raw(),
                 self.as_raw_mut_override(),
                 style.into(),
             );
@@ -54,14 +44,14 @@ impl BufferParams {
             } else {
                 Ok(())
             }
-        }
+        })
     }
 
     /// Sets the join style for outside (reflex) corners between line segments.
     pub fn set_join_style(&mut self, style: JoinStyle) -> GResult<()> {
-        unsafe {
+        with_context(|ctx| unsafe {
             let ret = GEOSBufferParams_setJoinStyle_r(
-                self.get_raw_context(),
+                ctx.as_raw(),
                 self.as_raw_mut_override(),
                 style.into(),
             );
@@ -70,7 +60,7 @@ impl BufferParams {
             } else {
                 Ok(())
             }
-        }
+        })
     }
 
     /// Sets the limit on the mitre ratio used for very sharp corners.
@@ -84,18 +74,15 @@ impl BufferParams {
     /// allows controlling the maximum length of the join corner.
     /// Corners with a ratio which exceed the limit will be beveled.
     pub fn set_mitre_limit(&mut self, limit: f64) -> GResult<()> {
-        unsafe {
-            let ret = GEOSBufferParams_setMitreLimit_r(
-                self.get_raw_context(),
-                self.as_raw_mut_override(),
-                limit,
-            );
+        with_context(|ctx| unsafe {
+            let ret =
+                GEOSBufferParams_setMitreLimit_r(ctx.as_raw(), self.as_raw_mut_override(), limit);
             if ret == 0 {
                 Err(Error::GeosError("GEOSBufferParams_setMitreLimit_r".into()))
             } else {
                 Ok(())
             }
-        }
+        })
     }
 
     /// Sets the number of line segments used to approximate
@@ -119,9 +106,9 @@ impl BufferParams {
     /// (in other words, the computed buffer curve is always inside
     ///  the true curve).
     pub fn set_quadrant_segments(&mut self, quadsegs: i32) -> GResult<()> {
-        unsafe {
+        with_context(|ctx| unsafe {
             let ret = GEOSBufferParams_setQuadrantSegments_r(
-                self.get_raw_context(),
+                ctx.as_raw(),
                 self.as_raw_mut_override(),
                 quadsegs as _,
             );
@@ -132,7 +119,7 @@ impl BufferParams {
             } else {
                 Ok(())
             }
-        }
+        })
     }
 
     /// Sets whether the computed buffer should be single-sided.
@@ -148,10 +135,10 @@ impl BufferParams {
     /// The End Cap Style for single-sided buffers is always ignored, and forced to the
     /// equivalent of [`CapStyle::Flat`].
     pub fn set_single_sided(&mut self, is_single_sided: bool) -> GResult<()> {
-        unsafe {
+        with_context(|ctx| unsafe {
             let single_sided = if is_single_sided { 1 } else { 0 };
             let ret = GEOSBufferParams_setSingleSided_r(
-                self.get_raw_context(),
+                ctx.as_raw(),
                 self.as_raw_mut_override(),
                 single_sided,
             );
@@ -160,7 +147,7 @@ impl BufferParams {
             } else {
                 Ok(())
             }
-        }
+        })
     }
 }
 
@@ -170,7 +157,9 @@ unsafe impl Sync for BufferParams {}
 impl Drop for BufferParams {
     fn drop(&mut self) {
         if !self.ptr.is_null() {
-            unsafe { GEOSBufferParams_destroy_r(self.get_raw_context(), self.as_raw_mut()) };
+            with_context(|ctx| unsafe {
+                GEOSBufferParams_destroy_r(ctx.as_raw(), self.as_raw_mut())
+            });
         }
     }
 }
@@ -188,28 +177,6 @@ impl AsRawMut for BufferParams {
 
     unsafe fn as_raw_mut_override(&self) -> *mut Self::RawType {
         *self.ptr
-    }
-}
-
-impl ContextInteractions for BufferParams {
-    fn set_context_handle(&mut self, context: ContextHandle) {
-        self.context = Arc::new(context);
-    }
-
-    fn get_context_handle(&self) -> &ContextHandle {
-        &self.context
-    }
-}
-
-impl ContextHandling for BufferParams {
-    type Context = Arc<ContextHandle>;
-
-    fn get_raw_context(&self) -> GEOSContextHandle_t {
-        self.context.as_raw()
-    }
-
-    fn clone_context(&self) -> Arc<ContextHandle> {
-        Arc::clone(&self.context)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ mod wkb_writer;
 mod wkt_writer;
 
 pub(crate) use traits::{AsRaw, AsRawMut};
-pub use traits::{ContextHandling, ContextInteractions};
 
 #[cfg(test)]
 mod test;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,3 @@
-use crate::ContextHandle;
-use geos_sys::GEOSContextHandle_t;
-
 pub trait AsRaw {
     type RawType;
 
@@ -18,51 +15,4 @@ pub trait AsRawMut {
     ///
     /// A good example is `GEOSWKTWriter_getOutputDimension_r` (which is very likely a bug).
     unsafe fn as_raw_mut_override(&self) -> *mut Self::RawType;
-}
-
-pub trait ContextHandling {
-    type Context;
-
-    #[doc(hidden)]
-    fn get_raw_context(&self) -> GEOSContextHandle_t;
-    fn clone_context(&self) -> Self::Context;
-}
-
-pub trait ContextInteractions {
-    fn set_context_handle(&mut self, context: ContextHandle);
-    fn get_context_handle(&self) -> &ContextHandle;
-
-    /// Gets the last error (if any) from the [`ContextHandle`] held by this object.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use geos::{ContextInteractions, Geometry};
-    ///
-    /// let mut point_geom = Geometry::new_from_wkt("POINT (2.5 2.5)").expect("Invalid geometry");
-    /// // execute some calls on `point_geom`
-    /// point_geom.get_last_error();
-    /// // This is a shortcut for calling:
-    /// point_geom.get_context_handle().get_last_error();
-    /// ```
-    fn get_last_error(&self) -> Option<String> {
-        self.get_context_handle().get_last_error()
-    }
-
-    /// Gets the last notification (if any) from the [`ContextHandle`] held by this object.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use geos::{ContextInteractions, Geometry};
-    ///
-    /// let mut point_geom = Geometry::new_from_wkt("POINT (2.5 2.5)").expect("Invalid geometry");
-    /// // execute some calls on `point_geom`
-    /// point_geom.get_last_notification();
-    /// // This is a shortcut for calling:
-    /// point_geom.get_context_handle().get_last_notification();
-    /// ```
-    fn get_last_notification(&self) -> Option<String> {
-        self.get_context_handle().get_last_notification()
-    }
 }

--- a/src/wkb_writer.rs
+++ b/src/wkb_writer.rs
@@ -1,22 +1,20 @@
-use crate::context_handle::PtrWrap;
+use crate::context_handle::{with_context, PtrWrap};
 use crate::enums::{ByteOrder, OutputDimension};
 use crate::error::Error;
-use crate::{AsRaw, AsRawMut, ContextHandle, ContextHandling, ContextInteractions, GResult, Geom};
+use crate::{AsRaw, AsRawMut, ContextHandle, GResult, Geom};
 use c_vec::CVec;
 use geos_sys::*;
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 /// The `WKBWriter` type is used to generate `HEX` or `WKB` formatted output from [`Geometry`](crate::Geometry).
 ///
 /// # Example
 ///
 /// ```
-/// use geos::{ContextHandling, Geom, Geometry, WKBWriter};
+/// use geos::{Geom, Geometry, WKBWriter};
 ///
 /// let point_geom = Geometry::new_from_wkt("POINT (2.5 2.5)").expect("Invalid geometry");
-/// let mut writer = WKBWriter::new_with_context(point_geom.clone_context())
-///                            .expect("Failed to create WKBWriter");
+/// let mut writer = WKBWriter::new().expect("Failed to create WKBWriter");
 ///
 /// // Output as WKB
 /// let v: Vec<u8> = writer.write_wkb(&point_geom).unwrap().into();
@@ -30,7 +28,6 @@ use std::sync::Arc;
 /// ```
 pub struct WKBWriter {
     ptr: PtrWrap<*mut GEOSWKBWriter>,
-    context: Arc<ContextHandle>,
 }
 
 impl WKBWriter {
@@ -49,41 +46,19 @@ impl WKBWriter {
     ///            "POINT (2.5 2.5)");
     /// ```
     pub fn new() -> GResult<WKBWriter> {
-        match ContextHandle::init_e(Some("WKBWriter::new")) {
-            Ok(context_handle) => Self::new_with_context(Arc::new(context_handle)),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Creates a new `WKBWriter` instance with a given context.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use geos::{ContextHandling, Geom, Geometry, WKBWriter};
-    ///
-    /// let point_geom = Geometry::new_from_wkt("POINT (2.5 2.5)").expect("Invalid geometry");
-    /// let mut writer = WKBWriter::new_with_context(point_geom.clone_context())
-    ///                            .expect("Failed to create WKBWriter");
-    ///
-    /// let v: Vec<u8> = writer.write_wkb(&point_geom).unwrap().into();
-    /// assert_eq!(Geometry::new_from_wkb(&v).unwrap().to_wkt_precision(1).unwrap(),
-    ///            "POINT (2.5 2.5)");
-    /// ```
-    pub fn new_with_context(context: Arc<ContextHandle>) -> GResult<WKBWriter> {
-        unsafe {
-            let ptr = GEOSWKBWriter_create_r(context.as_raw());
-            WKBWriter::new_from_raw(ptr, context, "new_with_context")
-        }
+        with_context(|ctx| unsafe {
+            let ptr = GEOSWKBWriter_create_r(ctx.as_raw());
+            WKBWriter::new_from_raw(ptr, ctx, "new_with_context")
+        })
     }
 
     pub(crate) unsafe fn new_from_raw(
         ptr: *mut GEOSWKBWriter,
-        context: Arc<ContextHandle>,
+        ctx: &ContextHandle,
         caller: &str,
     ) -> GResult<WKBWriter> {
         if ptr.is_null() {
-            let extra = if let Some(x) = context.get_last_error() {
+            let extra = if let Some(x) = ctx.get_last_error() {
                 format!("\nLast error: {x}")
             } else {
                 String::new()
@@ -92,10 +67,7 @@ impl WKBWriter {
                 "WKBWriter::{caller}{extra}",
             )));
         }
-        Ok(WKBWriter {
-            ptr: PtrWrap(ptr),
-            context,
-        })
+        Ok(WKBWriter { ptr: PtrWrap(ptr) })
     }
 
     /// Writes out the given `geometry` as WKB format.
@@ -114,9 +86,9 @@ impl WKBWriter {
     /// ```
     pub fn write_wkb<G: Geom>(&mut self, geometry: &G) -> GResult<CVec<u8>> {
         let mut size = 0;
-        unsafe {
+        with_context(|ctx| unsafe {
             let ptr = GEOSWKBWriter_write_r(
-                self.get_raw_context(),
+                ctx.as_raw(),
                 self.as_raw_mut(),
                 geometry.as_raw(),
                 &mut size,
@@ -129,7 +101,7 @@ impl WKBWriter {
             } else {
                 Ok(CVec::new(ptr, size as _))
             }
-        }
+        })
     }
 
     /// Writes out the given `geometry` as WKB format.
@@ -149,9 +121,9 @@ impl WKBWriter {
     /// ```
     pub fn write_hex<G: Geom>(&mut self, geometry: &G) -> GResult<CVec<u8>> {
         let mut size = 0;
-        unsafe {
+        with_context(|ctx| unsafe {
             let ptr = GEOSWKBWriter_writeHEX_r(
-                self.get_raw_context(),
+                ctx.as_raw(),
                 self.as_raw_mut(),
                 geometry.as_raw(),
                 &mut size,
@@ -164,7 +136,7 @@ impl WKBWriter {
             } else {
                 Ok(CVec::new(ptr, size as _))
             }
-        }
+        })
     }
 
     /// Sets the number of dimensions to be used when calling [`WKBWriter::write_wkb`] or
@@ -192,13 +164,9 @@ impl WKBWriter {
     /// assert_eq!(wkt_writer.write(&geom).unwrap(), "POINT Z (1.1 2.2 3.3)");
     /// ```
     pub fn set_output_dimension(&mut self, dimension: OutputDimension) {
-        unsafe {
-            GEOSWKBWriter_setOutputDimension_r(
-                self.get_raw_context(),
-                self.as_raw_mut(),
-                dimension.into(),
-            )
-        }
+        with_context(|ctx| unsafe {
+            GEOSWKBWriter_setOutputDimension_r(ctx.as_raw(), self.as_raw_mut(), dimension.into())
+        })
     }
 
     /// Returns the number of dimensions to be used when calling [`WKBWriter::write_wkb`].
@@ -216,10 +184,10 @@ impl WKBWriter {
     /// assert_eq!(writer.get_out_dimension(), Ok(OutputDimension::ThreeD));
     /// ```
     pub fn get_out_dimension(&self) -> GResult<OutputDimension> {
-        unsafe {
-            let out = GEOSWKBWriter_getOutputDimension_r(self.get_raw_context(), self.as_raw());
+        with_context(|ctx| unsafe {
+            let out = GEOSWKBWriter_getOutputDimension_r(ctx.as_raw(), self.as_raw());
             OutputDimension::try_from(out).map_err(|e| Error::GenericError(e.to_owned()))
-        }
+        })
     }
 
     /// Gets WKB byte order.
@@ -235,10 +203,10 @@ impl WKBWriter {
     /// assert_eq!(writer.get_wkb_byte_order(), Ok(ByteOrder::LittleEndian));
     /// ```
     pub fn get_wkb_byte_order(&self) -> GResult<ByteOrder> {
-        unsafe {
-            let out = GEOSWKBWriter_getByteOrder_r(self.get_raw_context(), self.as_raw());
+        with_context(|ctx| unsafe {
+            let out = GEOSWKBWriter_getByteOrder_r(ctx.as_raw(), self.as_raw());
             ByteOrder::try_from(out).map_err(|e| Error::GenericError(e.to_owned()))
-        }
+        })
     }
 
     /// Sets WKB byte order.
@@ -254,13 +222,9 @@ impl WKBWriter {
     /// assert_eq!(writer.get_wkb_byte_order(), Ok(ByteOrder::LittleEndian));
     /// ```
     pub fn set_wkb_byte_order(&mut self, byte_order: ByteOrder) {
-        unsafe {
-            GEOSWKBWriter_setByteOrder_r(
-                self.get_raw_context(),
-                self.as_raw_mut(),
-                byte_order.into(),
-            )
-        }
+        with_context(|ctx| unsafe {
+            GEOSWKBWriter_setByteOrder_r(ctx.as_raw(), self.as_raw_mut(), byte_order.into())
+        })
     }
 
     /// Gets if output will include SRID.
@@ -277,8 +241,8 @@ impl WKBWriter {
     /// ```
     #[allow(non_snake_case)]
     pub fn get_include_SRID(&self) -> GResult<bool> {
-        unsafe {
-            let out = GEOSWKBWriter_getIncludeSRID_r(self.get_raw_context(), self.as_raw());
+        with_context(|ctx| unsafe {
+            let out = GEOSWKBWriter_getIncludeSRID_r(ctx.as_raw(), self.as_raw());
             if out < 0 {
                 Err(Error::GenericError(
                     "GEOSWKBWriter_getIncludeSRID_r failed".to_owned(),
@@ -286,7 +250,7 @@ impl WKBWriter {
             } else {
                 Ok(out != 0)
             }
-        }
+        })
     }
 
     /// Sets if output will include SRID.
@@ -303,13 +267,9 @@ impl WKBWriter {
     /// ```
     #[allow(non_snake_case)]
     pub fn set_include_SRID(&mut self, include_SRID: bool) {
-        unsafe {
-            GEOSWKBWriter_setIncludeSRID_r(
-                self.get_raw_context(),
-                self.as_raw_mut(),
-                include_SRID as _,
-            )
-        }
+        with_context(|ctx| unsafe {
+            GEOSWKBWriter_setIncludeSRID_r(ctx.as_raw(), self.as_raw_mut(), include_SRID as _)
+        })
     }
 }
 
@@ -318,36 +278,7 @@ unsafe impl Sync for WKBWriter {}
 
 impl Drop for WKBWriter {
     fn drop(&mut self) {
-        unsafe { GEOSWKBWriter_destroy_r(self.get_raw_context(), self.as_raw_mut()) };
-    }
-}
-
-impl ContextInteractions for WKBWriter {
-    /// Set the context handle to the `WKBWriter`.
-    ///
-    /// ```
-    /// use geos::{ContextInteractions, ContextHandle, WKBWriter};
-    ///
-    /// let context_handle = ContextHandle::init().expect("invalid init");
-    /// let mut writer = WKBWriter::new().expect("failed to create WKT writer");
-    /// context_handle.set_notice_message_handler(Some(Box::new(|s| println!("new message: {}", s))));
-    /// writer.set_context_handle(context_handle);
-    /// ```
-    fn set_context_handle(&mut self, context: ContextHandle) {
-        self.context = Arc::new(context);
-    }
-
-    /// Get the context handle of the `WKBWriter`.
-    ///
-    /// ```
-    /// use geos::{ContextInteractions, WKBWriter};
-    ///
-    /// let mut writer = WKBWriter::new().expect("failed to create WKT writer");
-    /// let context = writer.get_context_handle();
-    /// context.set_notice_message_handler(Some(Box::new(|s| println!("new message: {}", s))));
-    /// ```
-    fn get_context_handle(&self) -> &ContextHandle {
-        &self.context
+        with_context(|ctx| unsafe { GEOSWKBWriter_destroy_r(ctx.as_raw(), self.as_raw_mut()) });
     }
 }
 
@@ -364,17 +295,5 @@ impl AsRawMut for WKBWriter {
 
     unsafe fn as_raw_mut_override(&self) -> *mut Self::RawType {
         *self.ptr
-    }
-}
-
-impl ContextHandling for WKBWriter {
-    type Context = Arc<ContextHandle>;
-
-    fn get_raw_context(&self) -> GEOSContextHandle_t {
-        self.context.as_raw()
-    }
-
-    fn clone_context(&self) -> Arc<ContextHandle> {
-        Arc::clone(&self.context)
     }
 }


### PR DESCRIPTION
This PR is follow-up of my previous issue #141 and also reaction to #160. (I don't think there is a memory leak, but this PR does lower memory footprint of every geometry by little more than 1kB as that is roughly the size of geos context, which would be reused with my PR and not allocated for every geometry.)

I see geos context as just an implementation detail of propagating error messages from c++ geos exceptions through geos c api in reentrant way. To address questions in #141: I dont't think the context is useful from user's point of view and I would say it is better/simpler to not have it in public api at all. I also think that context should not be a property of geometry for the same reason (and because unnecessarily used memory). And also I don't see it useful to be able to set own error handler as the context is already used to propagate geos errors to `GResult`. The original c++ geos api has nothing like the context and also python geos wrapper `shapely` is using geos context only as an internal implementation detail and is not accessible to users.

Another reason for this PR is that geos context is not thread-safe (it's not `Sync`), so this PR makes things correct. Although right now it seems that the worst case is possibly corrupted error message which is not severe problem really, but still.

So this is my suggestion :)