### PR TITLE
Add `LineString` check for `project`

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -2158,6 +2158,9 @@ impl$(<$lt>)? Geom for $ty_name$(<$lt>)? {
     }
 
     fn project<G: Geom>(&self, p: &G) -> GResult<f64> {
+        if self.geometry_type() != GeometryTypes::LineString {
+            return Err(Error::GenericError("Geometry must be a LineString".to_owned()));
+        }
         if p.geometry_type() != GeometryTypes::Point {
             return Err(Error::GenericError("Second geometry must be a Point".to_owned()));
         }
@@ -2172,6 +2175,9 @@ impl$(<$lt>)? Geom for $ty_name$(<$lt>)? {
     }
 
     fn project_normalized<G: Geom>(&self, p: &G) -> GResult<f64> {
+        if self.geometry_type() != GeometryTypes::LineString {
+            return Err(Error::GenericError("Geometry must be a LineString".to_owned()));
+        }
         if p.geometry_type() != GeometryTypes::Point {
             return Err(Error::GenericError("Second geometry must be a Point".to_owned()));
         }


### PR DESCRIPTION
This PR prevents a crash when `project` is called on something else than a `LineString`.