### PR TITLE
Add macros to validate every GEOS call (and much more)

### DIFF
--- a/examples/verbose_example.rs
+++ b/examples/verbose_example.rs
@@ -29,7 +29,7 @@ fn fun() -> Result<(), Error> {
         g4.to_wkt_precision(1)
     );
     println!("Geom4 contains centroid of geom1 : {:?}", g3.contains(&g4)?);
-    println!("Geom4 is valid ? : {}", g3.is_valid());
+    println!("Geom4 is valid ? : {:?}", g3.is_valid()?);
     Ok(())
 }
 

--- a/src/buffer_params.rs
+++ b/src/buffer_params.rs
@@ -2,13 +2,13 @@ use crate::context_handle::with_context;
 use crate::enums::CapStyle;
 use crate::functions::{errcheck, nullcheck};
 use crate::traits::as_raw_mut_impl;
-use crate::{AsRaw, AsRawMut, GResult, JoinStyle, PtrWrap};
-
+use crate::{AsRaw, AsRawMut, GResult, JoinStyle};
 use geos_sys::*;
+use std::ptr::NonNull;
 
 /// Contains the parameters which describe how a [Geometry](crate::Geometry) buffer should be constructed using [`buffer_with_params`](crate::Geom::buffer_with_params)
 pub struct BufferParams {
-    ptr: PtrWrap<*mut GEOSBufferParams>,
+    ptr: NonNull<GEOSBufferParams>,
 }
 
 /// Build options for a [`BufferParams`] object
@@ -25,9 +25,7 @@ impl BufferParams {
     pub fn new() -> GResult<BufferParams> {
         with_context(|ctx| unsafe {
             let ptr = nullcheck!(GEOSBufferParams_create_r(ctx.as_raw()))?;
-            Ok(BufferParams {
-                ptr: PtrWrap(ptr.as_ptr()),
-            })
+            Ok(BufferParams { ptr })
         })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,78 +2,24 @@ use std::{self, fmt};
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub enum Error {
-    InvalidGeometry(String),
+    GeosError((&'static str, Option<String>)),
     ImpossibleOperation(String),
-    GeosError(String),
-    GeosFunctionError(PredicateType, i32),
-    NoConstructionFromNullPtr(String),
     ConversionError(String),
     GenericError(String),
-    VoronoiError(String),
-    NormalizeError(String),
 }
 
 impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::InvalidGeometry(ref s) => write!(f, "Invalid geometry, {s}"),
-            Error::ImpossibleOperation(ref s) => write!(f, "Impossible operation, {s}"),
-            Error::GeosError(ref s) => write!(f, "error while calling libgeos while {s}"),
-            Error::GeosFunctionError(p, e) => write!(
-                f,
-                "error while calling libgeos method {p} (error number = {e})",
-            ),
-            Error::NoConstructionFromNullPtr(ref s) => write!(
-                f,
-                "impossible to build a geometry from a nullptr in \"{s}\"",
-            ),
-            Error::NormalizeError(ref s) => write!(f, "failed to normalize: {s}"),
-            Error::ConversionError(ref s) => write!(f, "impossible to convert geometry, {s}"),
-            Error::GenericError(ref s) => write!(f, "generic error: {s}"),
-            Error::VoronoiError(ref s) => write!(f, "voronoi error: {s}"),
+        match self {
+            Error::GeosError((caller, Some(err))) => write!(f, "{caller} failed with {err}"),
+            Error::GeosError((caller, None)) => write!(f, "{caller} failed"),
+            Error::ImpossibleOperation(ref s) => write!(f, "impossible operation: {s}"),
+            Error::ConversionError(ref s) => write!(f, "impossible to convert geometry: {s}"),
+            Error::GenericError(ref s) => write!(f, "{s}"),
         }
     }
 }
 
 pub type GResult<T> = std::result::Result<T, Error>;
-
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub enum PredicateType {
-    Intersects,
-    Crosses,
-    Disjoint,
-    Touches,
-    Overlaps,
-    Within,
-    Equals,
-    EqualsExact,
-    Covers,
-    CoveredBy,
-    Contains,
-    IsRing,
-    IsEmpty,
-    IsSimple,
-    PreparedContains,
-    PreparedContainsProperly,
-    PreparedCoveredBy,
-    PreparedCovers,
-    PreparedCrosses,
-    PreparedDisjoint,
-    PreparedIntersects,
-    PreparedOverlaps,
-    PreparedTouches,
-    PreparedWithin,
-    PreparedContainsXY,
-    PreparedIntersectsXY,
-    Normalize,
-    RelatePattern,
-    EqualsIdentical,
-}
-
-impl std::fmt::Display for PredicateType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}

--- a/src/from_geojson.rs
+++ b/src/from_geojson.rs
@@ -103,11 +103,11 @@ impl TryFrom<&Geometry> for GGeometry {
                 GGeometry::create_multipolygon(ggpolys)
             }
             Value::GeometryCollection(ref geoms) => {
-                let _geoms = geoms
+                let geoms = geoms
                     .iter()
-                    .map(|geom| geom.try_into())
+                    .map(TryInto::try_into)
                     .collect::<GResult<Vec<GGeometry>>>()?;
-                GGeometry::create_geometry_collection(_geoms)
+                GGeometry::create_geometry_collection(geoms)
             }
         }
     }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,69 +1,74 @@
-use crate::context_handle::{with_context, PtrWrap};
+use crate::context_handle::with_context;
 use crate::enums::*;
-use crate::error::{Error, GResult, PredicateType};
+use crate::error::{Error, GResult};
 use crate::geometry::Geometry;
 use crate::{AsRawMut, ContextHandle, Geom};
 use geos_sys::*;
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use std::str;
+use std::ptr::NonNull;
 
 // We need to cleanup only the char* from geos, the const char* are not to be freed.
 // this has to be checked method by method in geos
 // so we provide 2 method to wrap a char* to a string, one that manage (and thus free) the underlying char*
 // and one that does not free it
-pub(crate) unsafe fn unmanaged_string(raw_ptr: *const c_char, caller: &str) -> GResult<String> {
-    if raw_ptr.is_null() {
-        return Err(Error::NoConstructionFromNullPtr(format!(
-            "{caller}::unmanaged_string",
-        )));
-    }
-    let c_str = CStr::from_ptr(raw_ptr);
-    match str::from_utf8(c_str.to_bytes()) {
-        Ok(s) => Ok(s.to_string()),
-        Err(e) => Err(Error::GenericError(format!(
-            "{caller}::unmanaged_string failed: {e}",
-        ))),
-    }
+pub(crate) unsafe fn unmanaged_string(ptr: NonNull<c_char>) -> GResult<String> {
+    let c_str = CStr::from_ptr(ptr.as_ptr());
+    String::from_utf8(c_str.to_bytes().to_vec())
+        .map_err(|e| Error::GenericError(format!("unmanaged_string failed with {e}")))
 }
 
-pub(crate) unsafe fn managed_string(
-    raw_ptr: *mut c_char,
-    ctx: &ContextHandle,
-    caller: &str,
-) -> GResult<String> {
-    if raw_ptr.is_null() {
-        return Err(Error::NoConstructionFromNullPtr(format!(
-            "{caller}::managed_string",
-        )));
-    }
-    let s = unmanaged_string(raw_ptr, caller);
-    GEOSFree_r(ctx.as_raw(), raw_ptr as *mut _);
+pub(crate) unsafe fn managed_string(ptr: NonNull<c_char>, ctx: &ContextHandle) -> GResult<String> {
+    let s = unmanaged_string(ptr);
+    GEOSFree_r(ctx.as_raw(), ptr.as_ptr().cast());
     s
 }
 
 pub fn version() -> GResult<String> {
-    unsafe { unmanaged_string(GEOSversion(), "version") }
-}
-
-pub(crate) fn check_geos_predicate(val: i8, p: PredicateType) -> GResult<bool> {
-    match val {
-        1 => Ok(true),
-        0 => Ok(false),
-        _ => Err(Error::GeosFunctionError(p, val as _)),
+    unsafe {
+        let Some(v) = NonNull::new(GEOSversion().cast_mut()) else {
+            return Err(Error::GeosError(("GEOSversion", None)));
+        };
+        unmanaged_string(v)
     }
 }
 
-pub(crate) fn check_ret(val: i32, p: PredicateType) -> GResult<()> {
-    match val {
-        1 => Ok(()),
-        _ => Err(Error::GeosFunctionError(p, val)),
-    }
+macro_rules! nullcheck {
+    ($func:ident($ctx:ident.as_raw() $(, $($args:expr),* $(,)?)?)) => {{
+        let result = $func($ctx.as_raw()$(, $($args),*)?);
+        std::ptr::NonNull::new(result as *mut _).ok_or_else(|| {
+            $crate::Error::GeosError((stringify!($func), $ctx.get_last_error()))
+        })
+    }};
 }
+
+macro_rules! errcheck {
+    ($errval:expr, $func:ident($ctx:ident.as_raw() $(, $($args:expr),* $(,)?)?)) => {{
+        let result = $func($ctx.as_raw()$(, $($args),*)?);
+        if result == $errval {
+            Err($crate::Error::GeosError((stringify!($func), $ctx.get_last_error())))
+        } else {
+            Ok(result)
+        }
+    }};
+    ($($args:tt)*) => {
+        errcheck!(0, $($args)*)
+    };
+}
+
+macro_rules! predicate {
+    ($($args:tt)*) => {
+        Ok(errcheck!(2, $($args)*)? == 1)
+    };
+}
+
+pub(crate) use errcheck;
+pub(crate) use nullcheck;
+pub(crate) use predicate;
 
 pub(crate) fn check_same_geometry_type(geoms: &[Geometry], geom_type: GeometryTypes) -> bool {
-    geoms.iter().all(|g| g.geometry_type() == geom_type)
+    geoms.iter().all(|g| g.geometry_type() == Ok(geom_type))
 }
 
 pub(crate) fn create_multi_geom(
@@ -72,22 +77,23 @@ pub(crate) fn create_multi_geom(
 ) -> GResult<Geometry> {
     let nb_geoms = geoms.len();
     let res = {
-        let mut geoms: Vec<*mut GEOSGeometry> = geoms.iter_mut().map(|g| g.as_raw_mut()).collect();
+        let mut geoms: Vec<*mut GEOSGeometry> =
+            geoms.iter_mut().map(AsRawMut::as_raw_mut).collect();
         with_context(|ctx| unsafe {
-            let ptr = GEOSGeom_createCollection_r(
+            let ptr = nullcheck!(GEOSGeom_createCollection_r(
                 ctx.as_raw(),
                 output_type.into(),
-                geoms.as_mut_ptr() as *mut _,
+                geoms.as_mut_ptr().cast(),
                 nb_geoms as _,
-            );
-            Geometry::new_from_raw(ptr, ctx, "create_multi_geom")
+            ))?;
+            Ok(Geometry::new_from_raw(ptr))
         })
     };
 
     // we'll transfert the ownership of the ptr to the new Geometry,
     // so the old one needs to forget their c ptr to avoid double cleanup
-    for g in geoms.iter_mut() {
-        g.ptr = PtrWrap(::std::ptr::null_mut());
+    for g in geoms {
+        std::mem::forget(g);
     }
 
     res
@@ -102,7 +108,11 @@ pub fn orientation_index(
     py: f64,
 ) -> GResult<Orientation> {
     with_context(|ctx| unsafe {
-        Orientation::try_from(GEOSOrientationIndex_r(ctx.as_raw(), ax, ay, bx, by, px, py))
+        let ret = errcheck!(
+            2,
+            GEOSOrientationIndex_r(ctx.as_raw(), ax, ay, bx, by, px, py)
+        )?;
+        Orientation::try_from(ret)
     })
 }
 
@@ -125,7 +135,7 @@ pub fn segment_intersection(
         let mut cx = 0.;
         let mut cy = 0.;
 
-        let ret = GEOSSegmentIntersection_r(
+        let ret = errcheck!(GEOSSegmentIntersection_r(
             ctx.as_raw(),
             ax0,
             ay0,
@@ -137,42 +147,7 @@ pub fn segment_intersection(
             by1,
             &mut cx,
             &mut cy,
-        );
-        if ret == -1 {
-            Ok(None)
-        } else if ret == 0 {
-            Ok(Some((cx, cy)))
-        } else {
-            Err(Error::GenericError(
-                "GEOSSegmentIntersection_r failed".to_owned(),
-            ))
-        }
+        ))?;
+        Ok((ret != -1).then_some((cx, cy)))
     })
-}
-
-#[cfg(test)]
-mod test {
-    use super::check_geos_predicate;
-    use crate::error::PredicateType;
-
-    #[test]
-    fn check_geos_predicate_ok_test() {
-        assert!(!check_geos_predicate(0, PredicateType::Intersects).unwrap());
-    }
-
-    #[test]
-    fn check_geos_predicate_ko_test() {
-        assert!(check_geos_predicate(1, PredicateType::Intersects).unwrap());
-    }
-
-    #[test]
-    fn check_geos_predicate_err_test() {
-        let r = check_geos_predicate(42, PredicateType::Intersects);
-        let e = r.err().unwrap();
-
-        assert_eq!(
-            format!("{}", e),
-            "error while calling libgeos method Intersects (error number = 42)".to_string()
-        );
-    }
 }

--- a/src/geojson_writer.rs
+++ b/src/geojson_writer.rs
@@ -1,8 +1,9 @@
 use crate::context_handle::with_context;
 use crate::functions::*;
 use crate::traits::as_raw_mut_impl;
-use crate::{AsRaw, AsRawMut, GResult, Geom, PtrWrap};
+use crate::{AsRaw, AsRawMut, GResult, Geom};
 use geos_sys::*;
+use std::ptr::NonNull;
 
 /// The `GeoJSONWriter` type is used to generate `GeoJSON` formatted output from [`Geometry`](crate::Geometry).
 ///
@@ -17,7 +18,7 @@ use geos_sys::*;
 /// assert_eq!(writer.write(&point_geom).unwrap(), r#"{"type":"Point","coordinates":[2.5,2.5]}"#);
 /// ```
 pub struct GeoJSONWriter {
-    ptr: PtrWrap<*mut GEOSGeoJSONWriter>,
+    ptr: NonNull<GEOSGeoJSONWriter>,
 }
 
 impl GeoJSONWriter {
@@ -36,9 +37,7 @@ impl GeoJSONWriter {
     pub fn new() -> GResult<GeoJSONWriter> {
         with_context(|ctx| unsafe {
             let ptr = nullcheck!(GEOSGeoJSONWriter_create_r(ctx.as_raw()))?;
-            Ok(GeoJSONWriter {
-                ptr: PtrWrap(ptr.as_ptr()),
-            })
+            Ok(GeoJSONWriter { ptr })
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod traits;
 mod wkb_writer;
 mod wkt_writer;
 
-pub(crate) use traits::{AsRaw, AsRawMut, PtrWrap};
+pub(crate) use traits::{AsRaw, AsRawMut};
 
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod traits;
 mod wkb_writer;
 mod wkt_writer;
 
-pub(crate) use traits::{AsRaw, AsRawMut};
+pub(crate) use traits::{AsRaw, AsRawMut, PtrWrap};
 
 #[cfg(test)]
 mod test;

--- a/src/prepared_geometry.rs
+++ b/src/prepared_geometry.rs
@@ -1,9 +1,10 @@
 use crate::context_handle::with_context;
 use crate::functions::*;
-use crate::traits::{as_raw_impl, PtrWrap};
+use crate::traits::as_raw_impl;
 use crate::{AsRaw, GResult, Geom};
 use geos_sys::*;
 use std::marker::PhantomData;
+use std::ptr::NonNull;
 
 /// `PreparedGeometry` is an interface which prepares [`Geometry`](crate::Geometry) for greater performance
 /// on repeated calls.
@@ -23,7 +24,7 @@ use std::marker::PhantomData;
 /// assert_eq!(prepared_geom.contains(&geom2), Ok(true));
 /// ```
 pub struct PreparedGeometry<'a> {
-    ptr: PtrWrap<*const GEOSPreparedGeometry>,
+    ptr: NonNull<GEOSPreparedGeometry>,
     phantom: PhantomData<&'a ()>,
 }
 
@@ -43,7 +44,7 @@ impl<'a> PreparedGeometry<'a> {
         with_context(|ctx| unsafe {
             let ptr = nullcheck!(GEOSPrepare_r(ctx.as_raw(), g.as_raw()))?;
             Ok(PreparedGeometry {
-                ptr: PtrWrap(ptr.as_ptr()),
+                ptr,
                 phantom: PhantomData,
             })
         })

--- a/src/to_geo.rs
+++ b/src/to_geo.rs
@@ -12,7 +12,7 @@ fn to_geo<T: Geom>(other: &T) -> Result<Geometry<f64>, Error> {
     // We should at least use wkb, or even better implement a direct translation
     let wkt_str = other.to_wkt()?;
     geo_types::Geometry::try_from_wkt_str(&wkt_str)
-        .map_err(|e| Error::ConversionError(format!("impossible to read wkt: {}", e)))
+        .map_err(|e| Error::ConversionError(format!("impossible to read wkt: {e}")))
 }
 
 impl TryFrom<GGeometry> for Geometry<f64> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,15 +1,3 @@
-use std::ops::Deref;
-
-pub(crate) struct PtrWrap<T>(pub T);
-
-impl<T> Deref for PtrWrap<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 pub trait AsRaw {
     type RawType;
 
@@ -34,7 +22,7 @@ macro_rules! as_raw_impl {
             type RawType = $geos_type_name;
 
             fn as_raw(&self) -> *const Self::RawType {
-                *self.ptr
+                self.ptr.as_ptr()
             }
         }
     };
@@ -46,7 +34,7 @@ macro_rules! as_raw_mut_impl {
 
         impl AsRawMut for $type_name {
             unsafe fn as_raw_mut_override(&self) -> *mut Self::RawType {
-                *self.ptr
+                self.ptr.as_ptr()
             }
         }
     };

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,18 +1,56 @@
+use std::ops::Deref;
+
+pub(crate) struct PtrWrap<T>(pub T);
+
+impl<T> Deref for PtrWrap<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 pub trait AsRaw {
     type RawType;
 
     fn as_raw(&self) -> *const Self::RawType;
 }
 
-pub trait AsRawMut {
-    type RawType;
-
+pub trait AsRawMut: AsRaw {
     fn as_raw_mut(&mut self) -> *mut Self::RawType {
         unsafe { self.as_raw_mut_override() }
     }
+
     /// This method exists because in certain case, even though you don't run any mutable operation
     /// on the object, it still requires a mutable access.
     ///
     /// A good example is `GEOSWKTWriter_getOutputDimension_r` (which is very likely a bug).
     unsafe fn as_raw_mut_override(&self) -> *mut Self::RawType;
 }
+
+macro_rules! as_raw_impl {
+    ($type_name:ty, $geos_type_name:ty) => {
+        impl AsRaw for $type_name {
+            type RawType = $geos_type_name;
+
+            fn as_raw(&self) -> *const Self::RawType {
+                *self.ptr
+            }
+        }
+    };
+}
+
+macro_rules! as_raw_mut_impl {
+    ($type_name:ty, $geos_type_name:ty) => {
+        $crate::traits::as_raw_impl!($type_name, $geos_type_name);
+
+        impl AsRawMut for $type_name {
+            unsafe fn as_raw_mut_override(&self) -> *mut Self::RawType {
+                *self.ptr
+            }
+        }
+    };
+}
+
+pub(crate) use as_raw_impl;
+pub(crate) use as_raw_mut_impl;

--- a/src/voronoi.rs
+++ b/src/voronoi.rs
@@ -18,13 +18,9 @@ pub fn compute_voronoi<T: Borrow<Point<f64>>>(
 ) -> Result<Vec<Polygon<f64>>, Error> {
     let geom_points: GGeometry = points.try_into()?;
 
-    let mut voronoi = geom_points
-        .voronoi(envelope, tolerance, only_edges)
-        .map_err(|e| Error::VoronoiError(e.to_string()))?;
+    let mut voronoi = geom_points.voronoi(envelope, tolerance, only_edges)?;
 
-    voronoi
-        .normalize()
-        .map_err(|e| Error::NormalizeError(e.to_string()))?;
+    voronoi.normalize()?;
 
     voronoi
         .try_into()

--- a/src/wkb_writer.rs
+++ b/src/wkb_writer.rs
@@ -2,11 +2,12 @@ use crate::context_handle::with_context;
 use crate::enums::{ByteOrder, OutputDimension};
 use crate::functions::{errcheck, nullcheck, predicate};
 use crate::traits::as_raw_mut_impl;
-use crate::{AsRaw, AsRawMut, GResult, Geom, PtrWrap};
+use crate::{AsRaw, AsRawMut, GResult, Geom};
 
 use c_vec::CVec;
 use geos_sys::*;
 use std::convert::TryFrom;
+use std::ptr::NonNull;
 
 /// The `WKBWriter` type is used to generate `HEX` or `WKB` formatted output from [`Geometry`](crate::Geometry).
 ///
@@ -29,7 +30,7 @@ use std::convert::TryFrom;
 ///            "POINT (2.5 2.5)");
 /// ```
 pub struct WKBWriter {
-    ptr: PtrWrap<*mut GEOSWKBWriter>,
+    ptr: NonNull<GEOSWKBWriter>,
 }
 
 impl WKBWriter {
@@ -50,9 +51,7 @@ impl WKBWriter {
     pub fn new() -> GResult<WKBWriter> {
         with_context(|ctx| unsafe {
             let ptr = nullcheck!(GEOSWKBWriter_create_r(ctx.as_raw()))?;
-            Ok(WKBWriter {
-                ptr: PtrWrap(ptr.as_ptr()),
-            })
+            Ok(WKBWriter { ptr })
         })
     }
 

--- a/src/wkt_writer.rs
+++ b/src/wkt_writer.rs
@@ -1,9 +1,10 @@
 use crate::context_handle::with_context;
 use crate::functions::*;
 use crate::traits::as_raw_mut_impl;
-use crate::{AsRaw, AsRawMut, GResult, Geom, OutputDimension, PtrWrap};
+use crate::{AsRaw, AsRawMut, GResult, Geom, OutputDimension};
 use geos_sys::*;
 use std::convert::TryFrom;
+use std::ptr::NonNull;
 
 /// The `WKTWriter` type is used to generate `WKT` formatted output from [`Geometry`](crate::Geometry).
 ///
@@ -21,7 +22,7 @@ use std::convert::TryFrom;
 /// assert_eq!(writer.write(&point_geom).unwrap(), "POINT (2.5 2.5)");
 /// ```
 pub struct WKTWriter {
-    ptr: PtrWrap<*mut GEOSWKTWriter>,
+    ptr: NonNull<GEOSWKTWriter>,
 }
 
 impl WKTWriter {
@@ -43,9 +44,7 @@ impl WKTWriter {
     pub fn new() -> GResult<WKTWriter> {
         with_context(|ctx| unsafe {
             let ptr = nullcheck!(GEOSWKTWriter_create_r(ctx.as_raw()))?;
-            Ok(WKTWriter {
-                ptr: PtrWrap(ptr.as_ptr()),
-            })
+            Ok(WKTWriter { ptr })
         })
     }
 


### PR DESCRIPTION
Sorry about the changes salad. Every point can be adressed separately, but splitting all this into different PRs would have been a bit too challenging.  First commit should be the more readable, as the second one involves moves of large chunks of unchanged code.

- Add macros `nullcheck`, `errcheck`, `predicate` to validate every GEOS call. This makes geometry type checking in rust unnecessary, and allows retrieving the actual GEOS error messages for all functions.
- Refactor `Geom` trait to merge declaration and implementation.
- Refactor `ContextHandler`.
- Remove errors `InvalidGeometry`, `GeosFunctionError`, `NoConstructionFromNullPtr`, `VoronoiError`, `NormalizeError`.
- Update `GenericError` and `GeosError` formatting.
- `transform_xy` now return `Result<_, E: From<geos::Error>>`. (This allow using failible functions and have access to the exact error they may throw in the closure)
- `is_valid`, `geometry_type`, `clone` now return `GResult<_>`.
- `ConstGeometry` now holds `PhantomData` instead of reference to original.
- `get_num_dimensions` now return `i32` instead of `usize` (for consistency with `GEOSGeom_getDimensions_r` which can return -1, and uses 0 as the error code).
- `STRtree::iterate` and `STRtree::query` now requires `&mut self` instead of `&self` (for consistency with the C function signature, but is it really necessary or can it stay as it was before ?)
