### PR TITLE
Fix some typos in doc comments

### DIFF
--- a/src/coord_seq.rs
+++ b/src/coord_seq.rs
@@ -557,7 +557,7 @@ impl CoordSeq {
     ///   will be inferred from the number of dimensions on the geometry. A user may want to
     ///   override this for performance because GEOS always stores coordinates internally with 3 or
     ///   4 dimensions. So copying 2-dimensional GEOS coordinates to a 3-dimensional output buffer
-    ///   is slightly faster (a straight `memcpy`) than copying 2-dimensionalal GEOS coordinates to
+    ///   is slightly faster (a straight `memcpy`) than copying 2-dimensional GEOS coordinates to
     ///   a 2-dimensional output buffer (iterating over every coordinate and copying only the XY
     ///   values).
     ///

--- a/src/from_geo.rs
+++ b/src/from_geo.rs
@@ -123,7 +123,7 @@ impl TryFrom<MultiLineString<f64>> for GGeometry {
 struct LineRing<'a>(&'a LineString<f64>);
 
 /// Convert a `geo_types::LineString` to a geos `LinearRing`
-/// a `LinearRing` should be closed so cloase the geometry if needed
+/// (a `LinearRing` should be closed, so close the geometry if needed)
 impl TryFrom<LineRing<'_>> for GGeometry {
     type Error = Error;
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -637,7 +637,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
     /// Returns a geometry which represents all points whose distance from `self` is less than or
     /// equal to distance.
     ///
-    /// If the same paramters are used many times it's more efficient to use the
+    /// If the same parameters are used many times it's more efficient to use the
     /// [`buffer_with_params`](crate::Geom::buffer_with_params) operation.
     ///
     /// You can find nice examples and details about the options in this
@@ -761,7 +761,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the minimum bouding box of the given geometry.
+    /// Returns the minimum bounding box of the given geometry.
     ///
     /// # Example
     ///
@@ -1002,7 +1002,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
     /// // No intersection.
     /// assert_eq!(intersection_geom.is_empty()?, true);
     ///
-    /// // We slighty change the linestring so we have an intersection:
+    /// // We slightly change the linestring so we have an intersection:
     /// let mut geom2 = Geometry::new_from_wkt("LINESTRING(0 0, 0 2)")?;
     ///
     /// let intersection_geom = geom1.intersection(&geom2)?;
@@ -1155,7 +1155,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         with_context(|ctx| unsafe { predicate!(GEOSisClosed_r(ctx.as_raw(), self.as_raw())) })
     }
 
-    /// Returns the length of `self`. The unit depends of the SRID.
+    /// Returns the length of `self`. The unit depends on the SRID.
     ///
     /// # Example
     ///
@@ -1175,7 +1175,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the distance between `self` and `other`. The unit depends of the SRID.
+    /// Returns the distance between `self` and `other`. The unit depends on the SRID.
     ///
     /// # Example
     ///
@@ -1228,7 +1228,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the indexed distance between `self` and `other`. The unit depends of the SRID.
+    /// Returns the indexed distance between `self` and `other`. The unit depends on the SRID.
     ///
     /// Available using the `v3_7_0` feature.
     ///
@@ -1262,7 +1262,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the hausdorff distance between `self` and `other`. The unit depends of the SRID.
+    /// Returns the hausdorff distance between `self` and `other`. The unit depends on the SRID.
     ///
     /// # Example
     ///
@@ -1293,7 +1293,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the hausdorff distance between `self` and `other`. The unit depends of the SRID.
+    /// Returns the hausdorff distance between `self` and `other`. The unit depends on the SRID.
     ///
     /// # Example
     ///
@@ -1325,7 +1325,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the frechet distance between `self` and `other`. The unit depends of the SRID.
+    /// Returns the frechet distance between `self` and `other`. The unit depends on the SRID.
     ///
     /// Available using the `v3_7_0` feature.
     ///
@@ -1359,7 +1359,7 @@ pub trait Geom: AsRaw<RawType = GEOSGeometry> + Sized + Send + Sync {
         })
     }
 
-    /// Returns the frechet distance between `self` and `other`. The unit depends of the SRID.
+    /// Returns the frechet distance between `self` and `other`. The unit depends on the SRID.
     ///
     /// Available using the `v3_7_0` feature.
     ///
@@ -3167,7 +3167,7 @@ impl Geometry {
             Ok(Self::new_from_raw(ptr))
         });
 
-        // We transfered the ownership of the ptr to the new Geometry,
+        // We transferred the ownership of the ptr to the new Geometry,
         // so the old ones need to forget their c ptr to avoid double free.
         std::mem::forget(exterior);
         for interior in interiors {


### PR DESCRIPTION
Just a few typos I came across.
I saw one other ("each components" here: https://github.com/georust/geos/blob/master/src/geometry.rs#L896), but since it comes from a quote from another documentation (in which the typo appears), I left it as is.